### PR TITLE
Only do pop_back when ret is not empty

### DIFF
--- a/src/darabonba/http/Query.cpp
+++ b/src/darabonba/http/Query.cpp
@@ -83,7 +83,9 @@ Query::operator std::string() const {
   for (const auto &p : *this) {
     ret += encode(p.first) + '=' + encode(p.second) + '&';
   }
-  ret.pop_back();
+  if (!ret.empty()) {
+    ret.pop_back();
+  }
   return ret;
 }
 


### PR DESCRIPTION
When the ret is empty, there is no need to remove the trailing '&' character.