### PR TITLE
feat(http): 添加连接池配置和TCP keep-alive支持

### DIFF
--- a/include/darabonba/Core.hpp
+++ b/include/darabonba/Core.hpp
@@ -177,6 +177,30 @@ template <typename K, typename V> inline V getOrDefault(const std::map<K, V> &m,
 
 Json defaultVal(const Json &a, const Json &b);
 
+/**
+ * @brief Deserialize a JSON object to a Model-derived type
+ * 
+ * This is a convenience function that wraps the common pattern of
+ * converting a Json object to a strongly-typed Response/Model object.
+ * 
+ * Usage example:
+ * @code{.cpp}
+ *   // Instead of:
+ *   return Json(callApi(params, req, runtime)).get<CreateInstanceResponse>();
+ *   
+ *   // You can write:
+ *   return Darabonba::fromMap<CreateInstanceResponse>(callApi(params, req, runtime));
+ * @endcode
+ * 
+ * @tparam T The target type (must have from_json friend function defined)
+ * @param j The JSON object to deserialize
+ * @return Deserialized object of type T
+ */
+template <typename T>
+inline T fromMap(const Json &j) {
+  return j.template get<T>();
+}
+
 bool shouldRetry(const Policy::RetryOptions &options,
                  const Policy::RetryPolicyContext &ctx);
 int getBackoffTime(const Policy::RetryOptions &options,

--- a/include/darabonba/Core.hpp
+++ b/include/darabonba/Core.hpp
@@ -30,10 +30,10 @@ class MCurlHttpClient;
  */
 struct ConnectionPoolConfig {
   std::string host;
-  size_t max_connections = 5;        // Maximum connections in pool
+  size_t max_connections = 128;        // Maximum total connections (CURLMOPT_MAX_TOTAL_CONNECTIONS)
   long connection_idle_timeout = 300L; // Connection idle timeout (seconds)
   bool pipelining = false;           // Enable HTTP pipelining
-  size_t max_host_connections = 2;   // Max connections per host
+  size_t max_host_connections = 128;   // Max connections per host (CURLMOPT_MAX_HOST_CONNECTIONS)
   bool keep_alive = true;            // Enable TCP keep-alive
 
   // Compare operator for map keys

--- a/include/darabonba/Core.hpp
+++ b/include/darabonba/Core.hpp
@@ -54,7 +54,7 @@ struct ConnectionPoolConfig {
  */
 struct RequestConfig {
   int64_t connect_timeout_ms = 5000L;   // Per-request connection timeout
-  int64_t read_timeout_ms = 0L;         // Per-request read timeout
+  int64_t read_timeout_ms = 10000L;         // Per-request read timeout
   bool ignore_ssl = false;           // Per-request SSL verification
   std::string http_proxy;            // Per-request proxy
   std::string https_proxy;           // Per-request HTTPS proxy

--- a/include/darabonba/Core.hpp
+++ b/include/darabonba/Core.hpp
@@ -34,13 +34,15 @@ struct ConnectionPoolConfig {
   long connection_idle_timeout = 300L; // Connection idle timeout (seconds)
   bool pipelining = false;           // Enable HTTP pipelining
   size_t max_host_connections = 2;   // Max connections per host
-  
+  bool keep_alive = true;            // Enable TCP keep-alive
+
   // Compare operator for map keys
   bool operator<(const ConnectionPoolConfig& other) const {
     if (host != other.host) return host < other.host;
     if (max_connections != other.max_connections) return max_connections < other.max_connections;
     if (connection_idle_timeout != other.connection_idle_timeout) return connection_idle_timeout < other.connection_idle_timeout;
     if (pipelining != other.pipelining) return pipelining < other.pipelining;
+    if (keep_alive != other.keep_alive) return keep_alive < other.keep_alive;
     return max_host_connections < other.max_host_connections;
   }
 };

--- a/include/darabonba/Core.hpp
+++ b/include/darabonba/Core.hpp
@@ -177,8 +177,8 @@ template <typename K, typename V> inline V getOrDefault(const std::map<K, V> &m,
 
 Json defaultVal(const Json &a, const Json &b);
 
-bool allowRetry(const Policy::RetryOptions &options,
-                const Policy::RetryPolicyContext &ctx);
+bool shouldRetry(const Policy::RetryOptions &options,
+                 const Policy::RetryPolicyContext &ctx);
 int getBackoffTime(const Policy::RetryOptions &options,
                    const Policy::RetryPolicyContext &ctx);
 

--- a/include/darabonba/Core.hpp
+++ b/include/darabonba/Core.hpp
@@ -117,6 +117,63 @@ template <> inline bool isNull<std::nullptr_t>(const std::nullptr_t &) {
   return true;
 }
 
+// std::string 的特化：空字符串视为 null
+template <> inline bool isNull<std::string>(const std::string &str) {
+  return str.empty();
+}
+
+// std::shared_ptr 的特化：空指针视为 null
+template <typename T> inline bool isNull(const std::shared_ptr<T> &ptr) {
+  return ptr == nullptr;
+}
+
+// 容器类型特化：空容器视为 null
+// std::map
+template <typename K, typename V> inline bool isNull(const std::map<K, V> &m) {
+  return m.empty();
+}
+
+// std::vector
+template <typename T> inline bool isNull(const std::vector<T> &v) {
+  return v.empty();
+}
+
+/**
+ * @brief Safe map access - check if key exists and value is not null
+ * @param m The map to search
+ * @param key The key to look for
+ * @return true if key exists and value is not null (not empty string for string values)
+ */
+template <typename K, typename V> inline bool hasValue(const std::map<K, V> &m, const K &key) {
+  auto it = m.find(key);
+  return it != m.end() && !isNull(it->second);
+}
+
+/**
+ * @brief Check if map key is null (key not exists or value is null)
+ * @param m The map to search
+ * @param key The key to look for
+ * @return true if key not exists OR value is null (consistent with isNull(value) semantics)
+ * 
+ * Usage: isNull(map, key) instead of isNull(map[key]) which fails on const map
+ */
+template <typename K, typename V> inline bool isNull(const std::map<K, V> &m, const K &key) {
+  auto it = m.find(key);
+  return it == m.end() || isNull(it->second);
+}
+
+/**
+ * @brief Safe map get - returns value or default if key not found
+ * @param m The map to search
+ * @param key The key to look for
+ * @param defaultValue The value to return if key not found
+ * @return The value if key exists, otherwise defaultValue
+ */
+template <typename K, typename V> inline V getOrDefault(const std::map<K, V> &m, const K &key, const V &defaultValue) {
+  auto it = m.find(key);
+  return (it != m.end()) ? it->second : defaultValue;
+}
+
 Json defaultVal(const Json &a, const Json &b);
 
 bool allowRetry(const Policy::RetryOptions &options,

--- a/include/darabonba/Core.hpp
+++ b/include/darabonba/Core.hpp
@@ -31,7 +31,7 @@ class MCurlHttpClient;
 struct ConnectionPoolConfig {
   std::string host;
   size_t max_connections = 128;        // Maximum total connections (CURLMOPT_MAX_TOTAL_CONNECTIONS)
-  long connection_idle_timeout = 300L; // Connection idle timeout (seconds)
+  long connection_idle_timeout = 30L;  // Connection idle timeout (seconds), curl default is 118s
   bool pipelining = false;           // Enable HTTP pipelining
   size_t max_host_connections = 128;   // Max connections per host (CURLMOPT_MAX_HOST_CONNECTIONS)
   bool keep_alive = true;            // Enable TCP keep-alive

--- a/include/darabonba/Core.hpp
+++ b/include/darabonba/Core.hpp
@@ -1,6 +1,7 @@
 #ifndef DARABONBA_CORE_H_
 #define DARABONBA_CORE_H_
 
+#include <cstdint>
 #include <darabonba/Runtime.hpp>
 #include <darabonba/Type.hpp>
 #include <darabonba/http/MCurlResponse.hpp>
@@ -31,7 +32,7 @@ class MCurlHttpClient;
 struct ConnectionPoolConfig {
   std::string host;
   size_t max_connections = 128;        // Maximum total connections (CURLMOPT_MAX_TOTAL_CONNECTIONS)
-  long connection_idle_timeout = 30L;  // Connection idle timeout (seconds), curl default is 118s
+  int64_t connection_idle_timeout = 30L;  // Connection idle timeout (seconds), curl default is 118s
   bool pipelining = false;           // Enable HTTP pipelining
   size_t max_host_connections = 128;   // Max connections per host (CURLMOPT_MAX_HOST_CONNECTIONS)
   bool keep_alive = true;            // Enable TCP keep-alive
@@ -52,8 +53,8 @@ struct ConnectionPoolConfig {
  * Applied per individual request
  */
 struct RequestConfig {
-  long connect_timeout_ms = 5000L;   // Per-request connection timeout
-  long read_timeout_ms = 0L;         // Per-request read timeout
+  int64_t connect_timeout_ms = 5000L;   // Per-request connection timeout
+  int64_t read_timeout_ms = 0L;         // Per-request read timeout
   bool ignore_ssl = false;           // Per-request SSL verification
   std::string http_proxy;            // Per-request proxy
   std::string https_proxy;           // Per-request HTTPS proxy

--- a/include/darabonba/Exception.hpp
+++ b/include/darabonba/Exception.hpp
@@ -15,7 +15,6 @@ namespace Policy {
 class RetryPolicyContext;
 }
 
-// DaraException Class - Base exception class aligned with tea-python
 class DaraException : public std::exception {
 public:
   DaraException() = default;
@@ -27,7 +26,6 @@ public:
 
   DaraException(std::string &&msg) : message_(std::move(msg)) {}
 
-  // Dictionary-style initialization (aligned with tea-python)
   explicit DaraException(const Darabonba::Json &dic) {
     name_ = "DaraException";
     if (dic.contains("code") && !dic["code"].is_null()) {
@@ -99,7 +97,6 @@ public:
 
   virtual const char *what() const noexcept override { return message_.c_str(); }
 
-  // Getters for each field (aligned with tea-python)
   const std::string &getMessage() const { return message_; }
   const std::string &getName() const { return name_; }
   const std::string &getCode() const { return code_; }
@@ -118,7 +115,6 @@ public:
   void setStatusCode(int64_t statusCode) { statusCode_ = statusCode; }
   void setRetryAfter(int32_t retryAfter) { retryAfter_ = retryAfter; }
 
-  // String representation (aligned with tea-python)
   virtual std::string toString() const {
     return "Error: " + code_ + " " + message_ + " Response: " + data_.dump();
   }
@@ -153,14 +149,12 @@ public:
   ValidateException &operator=(ValidateException &&) = default;
 };
 
-// ResponseException Class (aligned with tea-python)
 class ResponseException : public DaraException {
 public:
   ResponseException();
   ResponseException(const ResponseException &) = default;
   ResponseException(ResponseException &&) = default;
   
-  // Constructor with individual parameters (aligned with tea-python)
   ResponseException(
       const std::string &code,
       const std::string &message,
@@ -185,7 +179,6 @@ public:
     stack_ = stack;
   }
 
-  // Dictionary-style initialization (aligned with tea-python)
   ResponseException(const Darabonba::Json &obj) : DaraException(obj) {
     name_ = "ResponseException";
     if (obj.contains("statusCode") && !obj["statusCode"].is_null()) {
@@ -219,7 +212,6 @@ public:
   void setStack(const std::string &stack) { stack_ = stack; }
   void setStatusMessage(const std::string &statusMessage) { statusMessage_ = statusMessage; }
 
-  // String representation (aligned with tea-python)
   std::string toString() const override {
     return "Error: " + code_ + " " + message_ + " Response: " + data_.dump();
   }
@@ -257,7 +249,6 @@ private:
   mutable std::string msg_;  // Cached message for what()
 };
 
-// RequiredArgumentException Class (aligned with tea-python)
 class RequiredArgumentException : public DaraException {
 public:
   explicit RequiredArgumentException(const std::string &arg);
@@ -274,7 +265,6 @@ private:
   std::string arg_;
 };
 
-// RetryError Class (aligned with tea-python)
 class RetryError : public std::exception {
 public:
   explicit RetryError(const std::string &message);
@@ -287,7 +277,6 @@ public:
 
   const char *what() const noexcept override;
 
-  // Getters (aligned with tea-python)
   const std::string &getMessage() const { return message_; }
   const std::string &getName() const { return name_; }
   const Darabonba::Json &getData() const { return data_; }
@@ -301,7 +290,6 @@ private:
   Darabonba::Json data_;
 };
 
-// UnretryableException Class (aligned with tea-python)
 class UnretryableException : public DaraException {
 public:
   // Constructor that takes RetryPolicyContext

--- a/include/darabonba/File.hpp
+++ b/include/darabonba/File.hpp
@@ -19,7 +19,6 @@
 namespace Darabonba {
 
 /**
- * File class aligned with tea-python's File class
  * Provides file operations: exists, path, length, createTime, modifyTime, read, write
  */
 class File {

--- a/include/darabonba/Logger.hpp
+++ b/include/darabonba/Logger.hpp
@@ -5,6 +5,19 @@
 #include <string>
 #include <atomic>
 
+// Windows SDK defines ERROR, WARNING, DEBUG, INFO as macros which conflict
+// with our enum values. Temporarily undef them during this header, then restore.
+#ifdef _WIN32
+  #pragma push_macro("ERROR")
+  #pragma push_macro("WARNING")
+  #pragma push_macro("DEBUG")
+  #pragma push_macro("INFO")
+  #undef ERROR
+  #undef WARNING
+  #undef DEBUG
+  #undef INFO
+#endif
+
 namespace Darabonba {
 
 /**
@@ -89,5 +102,13 @@ private:
 // Backward compatibility: allow global access without namespace
 using DarabonbaLogger = Darabonba::Logger;
 using DarabonbaLogLevel = Darabonba::LogLevel;
+
+// Restore Windows macros
+#ifdef _WIN32
+  #pragma pop_macro("INFO")
+  #pragma pop_macro("DEBUG")
+  #pragma pop_macro("WARNING")
+  #pragma pop_macro("ERROR")
+#endif
 
 #endif

--- a/include/darabonba/Logger.hpp
+++ b/include/darabonba/Logger.hpp
@@ -3,28 +3,91 @@
 
 #include <iostream>
 #include <string>
+#include <atomic>
 
+namespace Darabonba {
+
+/**
+ * @brief Log level enumeration
+ */
+enum class LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARNING = 2,
+  ERROR = 3,
+  OFF = 4  // Disable all logging
+};
+
+/**
+ * @brief Simple logger with configurable log level
+ *
+ * Usage:
+ *   // Set log level (default is WARNING)
+ *   Darabonba::Logger::setLevel(Darabonba::LogLevel::DEBUG);
+ *
+ *   // Log messages
+ *   Darabonba::Logger::debug("Debug message");
+ *   Darabonba::Logger::warning("Warning message");
+ *
+ *   // Disable logging
+ *   Darabonba::Logger::setLevel(Darabonba::LogLevel::OFF);
+ */
 class Logger {
 public:
+  /**
+   * @brief Set the global log level
+   * @param newLevel Messages below this level will be suppressed
+   */
+  static void setLevel(LogLevel newLevel) {
+    level().store(newLevel);
+  }
+
+  /**
+   * @brief Get the current log level
+   */
+  static LogLevel getLevel() {
+    return level().load();
+  }
+
   static void log(const std::string &val) {
-    std::cout << "[LOG] " << val << std::endl;
+    info(val);
   }
 
   static void info(const std::string &val) {
-    std::cout << "[INFO] " << val << std::endl;
+    if (level().load() <= LogLevel::INFO) {
+      std::cout << "[INFO] " << val << std::endl;
+    }
   }
 
   static void warning(const std::string &val) {
-    std::cout << "[WARNING] " << val << std::endl;
+    if (level().load() <= LogLevel::WARNING) {
+      std::cerr << "[WARNING] " << val << std::endl;
+    }
   }
 
   static void debug(const std::string &val) {
-    std::cout << "[DEBUG] " << val << std::endl;
+    if (level().load() <= LogLevel::DEBUG) {
+      std::cout << "[DEBUG] " << val << std::endl;
+    }
   }
 
   static void error(const std::string &val) {
-    std::cerr << "[ERROR] " << val << std::endl;
+    if (level().load() <= LogLevel::ERROR) {
+      std::cerr << "[ERROR] " << val << std::endl;
+    }
+  }
+
+private:
+  static std::atomic<LogLevel>& level() {
+    static std::atomic<LogLevel> instance(LogLevel::WARNING);
+    return instance;
   }
 };
+
+} // namespace Darabonba
+
+// Backward compatibility: allow global access without namespace
+using DarabonbaLogger = Darabonba::Logger;
+using DarabonbaLogLevel = Darabonba::LogLevel;
 
 #endif

--- a/include/darabonba/Model.hpp
+++ b/include/darabonba/Model.hpp
@@ -4,6 +4,150 @@
 #include <darabonba/Type.hpp>
 #include <regex>
 #include <type_traits>
+#include <sstream>
+#include <limits>
+#include <cstdint>
+
+namespace Darabonba {
+namespace detail {
+
+// ========== 通用模板（适用于所有复杂类型）==========
+template <typename T>
+inline T safe_convert(const Json& j) {
+  // 对于复杂类型，直接使用 get<T>()
+  // 如果类型不匹配，让 nlohmann::json 抛出异常
+  return j.template get<T>();
+}
+
+// ========== std::string 特化版本 ==========
+template <>
+inline std::string safe_convert<std::string>(const Json& j) {
+  // Fast path: 类型匹配时直接返回
+  try {
+    return j.get<std::string>();
+  } catch (...) {
+    // 继续尝试类型转换
+  }
+  
+  // Null 处理
+  if (j.is_null()) {
+    return "";
+  }
+  
+  // int -> string
+  if (j.is_number_integer()) {
+    return std::to_string(j.get<long long>());
+  }
+  
+  // float -> string
+  if (j.is_number_float()) {
+    double val = j.get<double>();
+    if (val == static_cast<long long>(val)) {
+      return std::to_string(static_cast<long long>(val));
+    } else {
+      return std::to_string(val);
+    }
+  }
+  
+  // bool -> string
+  if (j.is_boolean()) {
+    return j.get<bool>() ? "true" : "false";
+  }
+  
+  // 其他类型 -> string
+  return j.dump();
+}
+
+// ========== int32_t 特化版本 ==========
+template <>
+inline int32_t safe_convert<int32_t>(const Json& j) {
+  // Fast path
+  try {
+    return j.get<int32_t>();
+  } catch (...) {
+    // 继续尝试类型转换
+  }
+  
+  // Null 处理
+  if (j.is_null()) {
+    return 0;
+  }
+  
+  // string -> int32
+  if (j.is_string()) {
+    try {
+      std::string str = j.get<std::string>();
+      long long val = std::stoll(str);
+      if (val < INT32_MIN || val > INT32_MAX) {
+        throw std::out_of_range("Value out of int32 range");
+      }
+      return static_cast<int32_t>(val);
+    } catch (...) {
+      throw std::runtime_error("Cannot convert string to int32");
+    }
+  }
+  
+  // bool -> int32
+  if (j.is_boolean()) {
+    return j.get<bool>() ? 1 : 0;
+  }
+  
+  throw std::runtime_error("Cannot convert JSON value to int32");
+}
+
+// ========== int64_t 特化版本 ==========
+template <>
+inline int64_t safe_convert<int64_t>(const Json& j) {
+  try {
+    return j.get<int64_t>();
+  } catch (...) {}
+  
+  if (j.is_null()) {
+    return 0;
+  }
+  
+  if (j.is_string()) {
+    try {
+      return std::stoll(j.get<std::string>());
+    } catch (...) {
+      throw std::runtime_error("Cannot convert string to int64");
+    }
+  }
+  
+  if (j.is_boolean()) {
+    return j.get<bool>() ? 1 : 0;
+  }
+  
+  throw std::runtime_error("Cannot convert JSON value to int64");
+}
+
+// ========== bool 特化版本 ==========
+template <>
+inline bool safe_convert<bool>(const Json& j) {
+  try {
+    return j.get<bool>();
+  } catch (...) {}
+  
+  if (j.is_null()) {
+    return false;
+  }
+  
+  // string -> bool
+  if (j.is_string()) {
+    std::string str = j.get<std::string>();
+    return (str == "true" || str == "TRUE" || str == "1");
+  }
+  
+  // int -> bool
+  if (j.is_number()) {
+    return j.get<long long>() != 0;
+  }
+  
+  throw std::runtime_error("Cannot convert JSON value to bool");
+}
+
+} // namespace detail
+} // namespace Darabonba
 
 #define DARABONBA_PTR_TO_JSON(key, attr)                                       \
   if (obj.attr) {                                                              \
@@ -23,7 +167,8 @@
       obj.attr = nullptr;                                                      \
     } else {                                                                   \
       using Type = std::remove_reference<decltype(*obj.attr)>::type;           \
-      obj.attr = std::make_shared<Type>(j[#key].template get<Type>());         \
+      obj.attr = std::make_shared<Type>(                                       \
+          Darabonba::detail::safe_convert<Type>(j[#key]));                     \
     }                                                                          \
   }
 
@@ -37,8 +182,8 @@
     if (j[#key].is_null()) {                                                   \
       obj.attr = decltype(obj.attr)();                                         \
     } else {                                                                   \
-      obj.attr =                                                               \
-          j[#key].get<std::remove_reference<decltype(obj.attr)>::type>();      \
+      using Type = std::remove_reference<decltype(obj.attr)>::type;            \
+      obj.attr = Darabonba::detail::safe_convert<Type>(j[#key]);               \
     }                                                                          \
   }
 

--- a/include/darabonba/Number.hpp
+++ b/include/darabonba/Number.hpp
@@ -18,7 +18,7 @@ public:
 
   static int64_t itol(int val) { return val; }
 
-  static int ltoi(int64_t val) { return val; }
+  static int ltoi(int64_t val) { return static_cast<int>(val); }
 };
 } // namespace Darabonba
 

--- a/include/darabonba/Number.hpp
+++ b/include/darabonba/Number.hpp
@@ -1,6 +1,7 @@
 #ifndef DARABONBA_NUMBER_H_
 #define DARABONBA_NUMBER_H_
 
+#include <cstdint>
 #include <string>
 
 namespace Darabonba {
@@ -9,15 +10,15 @@ class Number {
 public:
   static int parseInt(const std::string &raw) { return std::stoi(raw); }
 
-  static long parseLong(const std::string &raw) { return std::stol(raw); }
+  static int64_t parseLong(const std::string &raw) { return std::stoll(raw); }
 
   static float parseFloat(const std::string &raw) { return std::stof(raw); }
 
   static double parseDouble(const std::string &raw) { return std::stod(raw); }
 
-  static long itol(int val) { return val; }
+  static int64_t itol(int val) { return val; }
 
-  static int ltoi(long val) { return val; }
+  static int ltoi(int64_t val) { return val; }
 };
 } // namespace Darabonba
 

--- a/include/darabonba/Runtime.hpp
+++ b/include/darabonba/Runtime.hpp
@@ -32,7 +32,7 @@ public:
     return obj;
   };
   virtual bool empty() const override {
-    return this->headers_ != nullptr && this->queries_ != nullptr;
+    return this->headers_ == nullptr && this->queries_ == nullptr;
   };
   // headers Field Functions
   bool hasHeaders() const { return this->headers_ != nullptr; };
@@ -130,17 +130,17 @@ public:
     return obj;
   };
   virtual bool empty() const override {
-    return this->autoretry_ != nullptr && this->ignoreSSL_ != nullptr &&
-           this->key_ != nullptr && this->cert_ != nullptr &&
-           this->ca_ != nullptr && this->maxAttempts_ != nullptr &&
-           this->backoffPolicy_ != nullptr && this->backoffPeriod_ != nullptr &&
-           this->readTimeout_ != nullptr && this->connectTimeout_ != nullptr &&
-           this->httpProxy_ != nullptr && this->httpsProxy_ != nullptr &&
-           this->noProxy_ != nullptr && this->maxIdleConns_ != nullptr &&
-           this->localAddr_ != nullptr && this->socks5Proxy_ != nullptr &&
-           this->socks5NetWork_ != nullptr && this->keepAlive_ != nullptr &&
-           this->extendsParameters_ != nullptr &&
-           this->retryOptions_ != nullptr;
+    return this->autoretry_ == nullptr && this->ignoreSSL_ == nullptr &&
+           this->key_ == nullptr && this->cert_ == nullptr &&
+           this->ca_ == nullptr && this->maxAttempts_ == nullptr &&
+           this->backoffPolicy_ == nullptr && this->backoffPeriod_ == nullptr &&
+           this->readTimeout_ == nullptr && this->connectTimeout_ == nullptr &&
+           this->httpProxy_ == nullptr && this->httpsProxy_ == nullptr &&
+           this->noProxy_ == nullptr && this->maxIdleConns_ == nullptr &&
+           this->localAddr_ == nullptr && this->socks5Proxy_ == nullptr &&
+           this->socks5NetWork_ == nullptr && this->keepAlive_ == nullptr &&
+           this->extendsParameters_ == nullptr &&
+           this->retryOptions_ == nullptr;
   };
   // autoretry Field Functions
   bool hasAutoretry() const { return this->autoretry_ != nullptr; };

--- a/include/darabonba/Runtime.hpp
+++ b/include/darabonba/Runtime.hpp
@@ -87,11 +87,12 @@ public:
     DARABONBA_PTR_TO_JSON(httpProxy, httpProxy_);
     DARABONBA_PTR_TO_JSON(httpsProxy, httpsProxy_);
     DARABONBA_PTR_TO_JSON(noProxy, noProxy_);
-    DARABONBA_PTR_TO_JSON(maxIdleConns, maxIdleConns_);
+    DARABONBA_PTR_TO_JSON(maxConnections, maxConnections_);
     DARABONBA_PTR_TO_JSON(localAddr, localAddr_);
     DARABONBA_PTR_TO_JSON(socks5Proxy, socks5Proxy_);
     DARABONBA_PTR_TO_JSON(socks5NetWork, socks5NetWork_);
     DARABONBA_PTR_TO_JSON(keepAlive, keepAlive_);
+    DARABONBA_PTR_TO_JSON(maxHostConnections, maxHostConnections_);
     DARABONBA_PTR_TO_JSON(extendsParameters, extendsParameters_);
     DARABONBA_PTR_TO_JSON(retryOptions, retryOptions_);
   };
@@ -109,11 +110,12 @@ public:
     DARABONBA_PTR_FROM_JSON(httpProxy, httpProxy_);
     DARABONBA_PTR_FROM_JSON(httpsProxy, httpsProxy_);
     DARABONBA_PTR_FROM_JSON(noProxy, noProxy_);
-    DARABONBA_PTR_FROM_JSON(maxIdleConns, maxIdleConns_);
+    DARABONBA_PTR_FROM_JSON(maxConnections, maxConnections_);
     DARABONBA_PTR_FROM_JSON(localAddr, localAddr_);
     DARABONBA_PTR_FROM_JSON(socks5Proxy, socks5Proxy_);
     DARABONBA_PTR_FROM_JSON(socks5NetWork, socks5NetWork_);
     DARABONBA_PTR_FROM_JSON(keepAlive, keepAlive_);
+    DARABONBA_PTR_FROM_JSON(maxHostConnections, maxHostConnections_);
     DARABONBA_PTR_FROM_JSON(extendsParameters, extendsParameters_);
     DARABONBA_PTR_FROM_JSON(retryOptions, retryOptions_);
   };
@@ -136,9 +138,10 @@ public:
            this->backoffPolicy_ == nullptr && this->backoffPeriod_ == nullptr &&
            this->readTimeout_ == nullptr && this->connectTimeout_ == nullptr &&
            this->httpProxy_ == nullptr && this->httpsProxy_ == nullptr &&
-           this->noProxy_ == nullptr && this->maxIdleConns_ == nullptr &&
+           this->noProxy_ == nullptr && this->maxConnections_ == nullptr &&
            this->localAddr_ == nullptr && this->socks5Proxy_ == nullptr &&
            this->socks5NetWork_ == nullptr && this->keepAlive_ == nullptr &&
+           this->maxHostConnections_ == nullptr &&
            this->extendsParameters_ == nullptr &&
            this->retryOptions_ == nullptr;
   };
@@ -262,14 +265,24 @@ public:
     DARABONBA_PTR_SET_VALUE(noProxy_, noProxy)
   };
 
-  // maxIdleConns Field Functions
-  bool hasMaxIdleConns() const { return this->maxIdleConns_ != nullptr; };
-  void deleteMaxIdleConns() { this->maxIdleConns_ = nullptr; };
-  inline int64_t getMaxIdleConns() const {
-    DARABONBA_PTR_GET_DEFAULT(maxIdleConns_, 0)
+  // maxConnections Field Functions
+  bool hasMaxConnections() const { return this->maxConnections_ != nullptr; };
+  void deleteMaxConnections() { this->maxConnections_ = nullptr; };
+  inline int64_t getMaxConnections() const {
+    DARABONBA_PTR_GET_DEFAULT(maxConnections_, 0)
   };
-  inline RuntimeOptions &setMaxIdleConns(int64_t maxIdleConns) {
-    DARABONBA_PTR_SET_VALUE(maxIdleConns_, maxIdleConns)
+  inline RuntimeOptions &setMaxConnections(int64_t maxConnections) {
+    DARABONBA_PTR_SET_VALUE(maxConnections_, maxConnections)
+  };
+
+  // maxHostConnections Field Functions
+  bool hasMaxHostConnections() const { return this->maxHostConnections_ != nullptr; };
+  void deleteMaxHostConnections() { this->maxHostConnections_ = nullptr; };
+  inline int64_t getMaxHostConnections() const {
+    DARABONBA_PTR_GET_DEFAULT(maxHostConnections_, 0)
+  };
+  inline RuntimeOptions &setMaxHostConnections(int64_t maxHostConnections) {
+    DARABONBA_PTR_SET_VALUE(maxHostConnections_, maxHostConnections)
   };
 
   // localAddr Field Functions
@@ -375,8 +388,8 @@ protected:
   std::shared_ptr<string> httpsProxy_ = nullptr;
   // agent blacklist
   std::shared_ptr<string> noProxy_ = nullptr;
-  // maximum number of connections
-  std::shared_ptr<int64_t> maxIdleConns_ = nullptr;
+  // maximum total connections (CURLMOPT_MAX_TOTAL_CONNECTIONS)
+  std::shared_ptr<int64_t> maxConnections_ = nullptr;
   // local addr
   std::shared_ptr<string> localAddr_ = nullptr;
   // SOCKS5 proxy
@@ -385,6 +398,8 @@ protected:
   std::shared_ptr<string> socks5NetWork_ = nullptr;
   // whether to enable keep-alive
   std::shared_ptr<bool> keepAlive_ = nullptr;
+  // maximum connections per host
+  std::shared_ptr<int64_t> maxHostConnections_ = nullptr;
   // Extends Parameters
   std::shared_ptr<ExtendsParameters> extendsParameters_ = nullptr;
   // Extends Parameters

--- a/include/darabonba/Runtime.hpp
+++ b/include/darabonba/Runtime.hpp
@@ -360,6 +360,14 @@ public:
   inline RuntimeOptions &setRetryOptions(RetryOptions &&retryOptions) {
     DARABONBA_PTR_SET_RVALUE(retryOptions_, retryOptions)
   };
+  
+  inline RuntimeOptions &setMaxIdleConns(string maxIdleConns) {
+    this->maxIdleConns_ = maxIdleConns;
+    return *this;
+  };
+  inline string getMaxIdleConns() const {
+    return this->maxIdleConns_;
+  };
 
 protected:
   // whether to try again
@@ -404,6 +412,8 @@ protected:
   std::shared_ptr<ExtendsParameters> extendsParameters_ = nullptr;
   // Extends Parameters
   std::shared_ptr<RetryOptions> retryOptions_ = nullptr;
+  // Declare MaxIdleConns
+  std::string maxIdleConns_;
 };
 
 } // namespace Darabonba

--- a/include/darabonba/Stream.hpp
+++ b/include/darabonba/Stream.hpp
@@ -45,9 +45,6 @@ public:
   static std::shared_ptr<OStream> toWritable(const Bytes &raw);
 
   static void reset(std::shared_ptr<Stream> raw);
-
-private:
-  static std::string cleanString(const std::string &str);
 };
 
 class IStream : public Stream {

--- a/include/darabonba/Stream.hpp
+++ b/include/darabonba/Stream.hpp
@@ -40,6 +40,8 @@ public:
 
   static std::shared_ptr<IStream> toReadable(const Bytes &raw);
 
+  static std::shared_ptr<IStream> toReadable(const Json &raw);
+
   static std::shared_ptr<OStream> toWritable(const std::string &raw);
 
   static std::shared_ptr<OStream> toWritable(const Bytes &raw);
@@ -132,7 +134,6 @@ public:
            std::ios_base::openmode mode = std::ios_base::in)
       : std::ifstream(filepath, mode), m_filepath(filepath), m_openmode(mode) {}
 
-  // 深拷贝构造函数
   IFStream(const IFStream &other)
       : std::basic_ios<char>(nullptr), std::ifstream(),
         m_filepath(other.m_filepath), m_openmode(other.m_openmode) {
@@ -141,13 +142,7 @@ public:
       this->open(m_filepath, m_openmode);
 
       if (this->is_open() && other.is_open()) {
-        // 使用 const_cast 来调用 tellg()
-        auto pos = const_cast<IFStream &>(other).tellg();
-        if (pos != std::streampos(-1)) {
-          this->seekg(pos);
-        }
-        // 获取状态也需要 const_cast
-        this->clear(const_cast<IFStream &>(other).rdstate());
+        this->clear(other.rdstate());
       }
     }
   }
@@ -156,7 +151,6 @@ public:
       : std::ifstream(std::move(other)),
         m_filepath(std::move(other.m_filepath)), m_openmode(other.m_openmode) {}
 
-  // 深拷贝赋值操作符
   IFStream &operator=(const IFStream &other) {
     if (this == &other) {
       return *this;
@@ -173,11 +167,7 @@ public:
       this->open(m_filepath, m_openmode);
 
       if (this->is_open() && other.is_open()) {
-        auto pos = const_cast<IFStream &>(other).tellg();
-        if (pos != std::streampos(-1)) {
-          this->seekg(pos);
-        }
-        this->clear(const_cast<IFStream &>(other).rdstate());
+        this->clear(other.rdstate());
       }
     }
 
@@ -202,6 +192,9 @@ public:
   virtual size_t read(char *buffer, size_t expectSize) override;
 
   virtual bool isFinished() const override { return eof(); }
+
+  // Public wrapper for protected is_open()
+  bool isOpen() const { return std::ifstream::is_open(); }
 
 private:
   std::string m_filepath;

--- a/include/darabonba/Time.hpp
+++ b/include/darabonba/Time.hpp
@@ -2,6 +2,7 @@
 #define DARABONBA_TIME_H_
 
 #include <chrono>
+#include <cstdint>
 #include <ctime>
 #include <darabonba/String.hpp>
 #include <string>
@@ -27,7 +28,7 @@ public:
     return buf;
   }
 
-  static void sleep(long milliseconds) {
+  static void sleep(int64_t milliseconds) {
     std::this_thread::sleep_for(std::chrono::microseconds(milliseconds));
   }
 

--- a/include/darabonba/Type.hpp
+++ b/include/darabonba/Type.hpp
@@ -7,9 +7,11 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 // 特化处理 nlohmann::json 类型：字符串类型提取值，其他类型保持原样
+// 需要同时提供 const 和非 const 版本，否则转发引用会优先匹配非 const 左值
 inline void appendToStream(std::ostringstream &oss, const nlohmann::json &arg) {
   if (arg.is_string()) {
     oss << arg.get<std::string>();
@@ -18,14 +20,32 @@ inline void appendToStream(std::ostringstream &oss, const nlohmann::json &arg) {
   }
 }
 
-// 通用模板处理其他类型
-template <typename T> void appendToStream(std::ostringstream &oss, T &&arg) {
+inline void appendToStream(std::ostringstream &oss, nlohmann::json &arg) {
+  if (arg.is_string()) {
+    oss << arg.get<std::string>();
+  } else {
+    oss << arg;
+  }
+}
+
+inline void appendToStream(std::ostringstream &oss, nlohmann::json &&arg) {
+  if (arg.is_string()) {
+    oss << arg.get<std::string>();
+  } else {
+    oss << arg;
+  }
+}
+
+// 通用模板处理其他类型（禁用 nlohmann::json 类型）
+template <typename T>
+typename std::enable_if<!std::is_same<typename std::decay<T>::type, nlohmann::json>::value>::type
+appendToStream(std::ostringstream &oss, T &&arg) {
   oss << std::forward<T>(arg);
 }
 
 template <typename First, typename... Args>
 void appendToStream(std::ostringstream &oss, First &&first, Args &&...args) {
-  oss << first;
+  appendToStream(oss, std::forward<First>(first));  // 调用单参数版本，确保 json 特化生效
   appendToStream(oss, std::forward<Args>(args)...);
 }
 

--- a/include/darabonba/Type.hpp
+++ b/include/darabonba/Type.hpp
@@ -9,8 +9,18 @@
 #include <string>
 #include <vector>
 
+// 特化处理 nlohmann::json 类型：字符串类型提取值，其他类型保持原样
+inline void appendToStream(std::ostringstream &oss, const nlohmann::json &arg) {
+  if (arg.is_string()) {
+    oss << arg.get<std::string>();
+  } else {
+    oss << arg;
+  }
+}
+
+// 通用模板处理其他类型
 template <typename T> void appendToStream(std::ostringstream &oss, T &&arg) {
-  oss << arg;
+  oss << std::forward<T>(arg);
 }
 
 template <typename First, typename... Args>

--- a/include/darabonba/http/FileField.hpp
+++ b/include/darabonba/http/FileField.hpp
@@ -102,6 +102,13 @@ public:
 
   virtual ~FileFormStream() { curl_mime_free(mime_); }
 
+  // Store FileField to keep it alive during curl request
+  void setFileField(std::shared_ptr<FileField> fileField) {
+    fileField_ = std::move(fileField);
+  }
+
+  std::shared_ptr<FileField> getFileField() const { return fileField_; }
+
   /**
    * @note This is a specail IStream class whose read method is implemented by
    * libcurl
@@ -191,6 +198,7 @@ protected:
   size_t index_ = 0;
   bool streaming_ = false;
   std::shared_ptr<IStream> streamingStream_ = nullptr;
+  std::shared_ptr<FileField> fileField_ = nullptr;
 };
 
 } // namespace Http

--- a/include/darabonba/http/MCurlHttpClient.hpp
+++ b/include/darabonba/http/MCurlHttpClient.hpp
@@ -22,7 +22,9 @@ class MCurlHttpClient {
   friend class MCurlResponseBody;
 
 public:
-  MCurlHttpClient() : mCurl_(curl_multi_init()) {}
+  MCurlHttpClient() 
+    : mCurl_(curl_multi_init()),
+      poolConfig_(std::make_shared<ConnectionPoolConfig>()) {}
   ~MCurlHttpClient() {
     stop();
     if (performThread_.joinable()) {
@@ -50,21 +52,23 @@ public:
   /**
    * @brief Set connection pool configuration
    * @param config The connection pool configuration to apply
-   * @note This will update the curl multi handle settings immediately if the client is running
+   * @note Thread-safe: uses atomic store for lock-free concurrent access.
+   *       The actual CURL multi handle update is deferred to the perform thread
+   *       to avoid calling curl_multi_setopt during curl_multi_perform.
    */
   void setConnectionPoolConfig(const ConnectionPoolConfig &config) {
-    poolConfig_ = config;
-    // Apply settings to curl multi handle if already running
-    if (running_ && mCurl_) {
-      applyConnectionPoolSettings();
-    }
+    std::atomic_store(&poolConfig_, std::make_shared<ConnectionPoolConfig>(config));
+    // Signal that config needs to be applied in perform thread
+    configNeedsUpdate_.store(true);
   }
 
   /**
    * @brief Get current connection pool configuration
+   * @note Thread-safe: uses atomic load for lock-free concurrent access
    */
-  const ConnectionPoolConfig& getConnectionPoolConfig() const {
-    return poolConfig_;
+  ConnectionPoolConfig getConnectionPoolConfig() const {
+    auto configPtr = std::atomic_load(&poolConfig_);
+    return configPtr ? *configPtr : ConnectionPoolConfig();
   }
 
 protected:
@@ -120,8 +124,12 @@ protected:
   std::condition_variable stopCV_;
   std::atomic<bool> stop_ = {false};
 
-  // Connection pool configuration
-  ConnectionPoolConfig poolConfig_;
+  // Flag to indicate config needs update in perform thread
+  std::atomic<bool> configNeedsUpdate_{false};
+
+  // Connection pool configuration (atomic for lock-free concurrent access)
+  // Use atomic_load/atomic_store for thread-safe read/write
+  std::shared_ptr<ConnectionPoolConfig> poolConfig_;
 };
 
 } // namespace Http

--- a/include/darabonba/http/MCurlHttpClient.hpp
+++ b/include/darabonba/http/MCurlHttpClient.hpp
@@ -1,3 +1,4 @@
+#include <darabonba/Core.hpp>
 #include <atomic>
 #include <condition_variable>
 #include <darabonba/Runtime.hpp>
@@ -46,6 +47,26 @@ public:
    */
   bool stop();
 
+  /**
+   * @brief Set connection pool configuration
+   * @param config The connection pool configuration to apply
+   * @note This will update the curl multi handle settings immediately if the client is running
+   */
+  void setConnectionPoolConfig(const ConnectionPoolConfig &config) {
+    poolConfig_ = config;
+    // Apply settings to curl multi handle if already running
+    if (running_ && mCurl_) {
+      applyConnectionPoolSettings();
+    }
+  }
+
+  /**
+   * @brief Get current connection pool configuration
+   */
+  const ConnectionPoolConfig& getConnectionPoolConfig() const {
+    return poolConfig_;
+  }
+
 protected:
   enum { WAIT_MS = 2000 };
 
@@ -73,6 +94,9 @@ protected:
 
   void clearQueue();
 
+  // Apply connection pool settings to curl multi handle
+  void applyConnectionPoolSettings();
+
   std::thread performThread_;
 
   std::atomic<bool> running_ = {false};
@@ -95,6 +119,9 @@ protected:
   std::mutex stopMutex_;
   std::condition_variable stopCV_;
   std::atomic<bool> stop_ = {false};
+
+  // Connection pool configuration
+  ConnectionPoolConfig poolConfig_;
 };
 
 } // namespace Http

--- a/include/darabonba/http/MCurlResponse.hpp
+++ b/include/darabonba/http/MCurlResponse.hpp
@@ -69,7 +69,7 @@ public:
   bool fetch();
 
 protected:
-  enum { MAX_SIZE = 6000 };
+  enum { MAX_SIZE = 10 * 1024 * 1024 };  // 10MB, 支持大响应体
 
   /**
    * @brief The maximum size of data stored in the body

--- a/include/darabonba/http/MCurlResponse.hpp
+++ b/include/darabonba/http/MCurlResponse.hpp
@@ -133,23 +133,16 @@ struct adl_serializer<std::shared_ptr<Darabonba::Http::MCurlResponseBody>> {
   static void
   to_json(json &j,
           const std::shared_ptr<Darabonba::Http::MCurlResponseBody> &body) {
-    if (body) {
-      j = reinterpret_cast<uintptr_t>(body.get());
-    } else {
-      j = nullptr;
-    }
+    // Stream objects cannot be meaningfully serialized.
+    // Serialize as null to prevent unsafe pointer casting.
+    (void)body;
+    j = nullptr;
   }
 
   static std::shared_ptr<Darabonba::Http::MCurlResponseBody>
-  from_json(const json &j) {
-    if (!j.is_null() && j.is_number_unsigned()) {
-      Darabonba::Http::MCurlResponseBody *ptr =
-          reinterpret_cast<Darabonba::Http::MCurlResponseBody *>(
-              j.get<uintptr_t>());
-      return std::shared_ptr<Darabonba::Http::MCurlResponseBody>(
-          ptr, [](Darabonba::Http::MCurlResponseBody *) {
-          }); // 不删除，因为所有权不明确
-    }
+  from_json(const json &) {
+    // Stream objects cannot be deserialized from JSON.
+    // Return nullptr; callers should create new stream objects as needed.
     return nullptr;
   }
 };

--- a/include/darabonba/http/ResponseBase.hpp
+++ b/include/darabonba/http/ResponseBase.hpp
@@ -114,7 +114,6 @@ public:
     return *this;
   }
 
-  // Status message (aligned with tea-python's DaraResponse.status_message)
   const std::string &getStatusMessage() const { return statusMessage_; }
   ResponseBase &setStatusMessage(const std::string &statusMessage) {
     statusMessage_ = statusMessage;

--- a/include/darabonba/http/URL.hpp
+++ b/include/darabonba/http/URL.hpp
@@ -11,9 +11,6 @@
 namespace Darabonba {
 namespace Http {
 
-/**
- * URL class with encoding utilities aligned with tea-python's Url class
- */
 class URL {
 public:
   explicit URL(const std::string &);
@@ -21,7 +18,6 @@ public:
   URL() = default;
 
   /**
-   * Parse a URL string and create a URL object (aligned with tea-python)
    * @param urlStr The URL string to parse
    * @return URL object
    */
@@ -29,12 +25,6 @@ public:
     return URL(urlStr);
   }
 
-  /**
-   * URL encode a string (aligned with tea-python's url_encode)
-   * Encodes each path segment separately, preserving '/' characters
-   * @param urlStr The string to encode
-   * @return URL encoded string
-   */
   static std::string urlEncode(const std::string &urlStr) {
     if (urlStr.empty()) {
       return "";
@@ -59,11 +49,6 @@ public:
     return result;
   }
 
-  /**
-   * Percent encode a URI string (aligned with tea-python's percent_encode)
-   * @param uri The URI string to encode
-   * @return Percent encoded string
-   */
   static std::string percentEncode(const std::string &uri) {
     if (uri.empty()) {
       return "";
@@ -83,7 +68,6 @@ public:
     }
 
     std::string result = encoded.str();
-    // Apply tea-python specific replacements
     // Replace %2B with %20 (space), keep %2A as is, replace %7E with ~
     size_t pos = 0;
     while ((pos = result.find("%7E", pos)) != std::string::npos) {
@@ -93,12 +77,6 @@ public:
     return result;
   }
 
-  /**
-   * Path encode a path string (aligned with tea-python's path_encode)
-   * Similar to urlEncode but specifically for paths
-   * @param path The path string to encode
-   * @return Path encoded string
-   */
   static std::string pathEncode(const std::string &path) {
     if (path.empty() || path == "/") {
       return path;

--- a/include/darabonba/policy/Retry.hpp
+++ b/include/darabonba/policy/Retry.hpp
@@ -21,18 +21,16 @@ const int MinDelayTime = 100;
 namespace Darabonba {
 namespace Policy {
 
-class RetryPolicyContext; // 前向声明
+class RetryPolicyContext;
 
-// BackoffPolicy 基类
+
 class BackoffPolicy {
 public:
-  // 友元函数实现 JSON 序列化
+
   friend void to_json(Darabonba::Json &j, const BackoffPolicy &obj) {
-    // 此宏需要支持序列化 std::string，增加处理逻辑在使用时
     DARABONBA_TO_JSON(policy, policy_);
   }
 
-  // 友元函数实现 JSON 反序列化
   friend void from_json(const Darabonba::Json &j, BackoffPolicy &obj) {
     DARABONBA_FROM_JSON(policy, policy_);
   }
@@ -354,15 +352,13 @@ protected:
 class RetryOptions {
 public:
   friend void to_json(Darabonba::Json &j, const RetryOptions &obj) {
-    j["retryable"] = obj.retryable_;
+    DARABONBA_TO_JSON(retryable, retryable_);
     DARABONBA_TO_JSON(retryCondition, retryCondition_);
     DARABONBA_TO_JSON(noRetryCondition, noRetryCondition_);
   }
 
   friend void from_json(const Darabonba::Json &j, RetryOptions &obj) {
-    if (j.contains("retryable") && !j["retryable"].is_null()) {
-      obj.retryable_ = j["retryable"].get<bool>();
-    }
+    DARABONBA_FROM_JSON(retryable, retryable_);
     DARABONBA_FROM_JSON(retryCondition, retryCondition_);
     DARABONBA_FROM_JSON(noRetryCondition, noRetryCondition_);
   }

--- a/include/darabonba/policy/Retry.hpp
+++ b/include/darabonba/policy/Retry.hpp
@@ -354,11 +354,15 @@ protected:
 class RetryOptions {
 public:
   friend void to_json(Darabonba::Json &j, const RetryOptions &obj) {
+    j["retryable"] = obj.retryable_;
     DARABONBA_TO_JSON(retryCondition, retryCondition_);
     DARABONBA_TO_JSON(noRetryCondition, noRetryCondition_);
   }
 
   friend void from_json(const Darabonba::Json &j, RetryOptions &obj) {
+    if (j.contains("retryable") && !j["retryable"].is_null()) {
+      obj.retryable_ = j["retryable"].get<bool>();
+    }
     DARABONBA_FROM_JSON(retryCondition, retryCondition_);
     DARABONBA_FROM_JSON(noRetryCondition, noRetryCondition_);
   }

--- a/src/darabonba/Core.cpp
+++ b/src/darabonba/Core.cpp
@@ -271,7 +271,7 @@ size_t Core::GetHttpClientCount() {
   return state.http_clients.size();
 }
 
-bool allowRetry(const RetryOptions &options, const RetryPolicyContext &ctx) {
+bool shouldRetry(const RetryOptions &options, const RetryPolicyContext &ctx) {
   if (ctx.getRetriesAttempted() == 0) {
     return true;
   }

--- a/src/darabonba/Core.cpp
+++ b/src/darabonba/Core.cpp
@@ -86,11 +86,14 @@ ConnectionPoolConfig getConnectionPoolConfig(Http::Request &request,
   // Read connection pool settings from runtime (these are Config-level values
   // passed by Client, not per-request RuntimeOptions)
   if (!runtime.is_null()) {
-    if (runtime.contains("maxIdleConns")) {
-      config.max_connections = static_cast<size_t>(runtime["maxIdleConns"].get<int64_t>());
+    if (runtime.contains("maxConnections")) {
+      config.max_connections = static_cast<size_t>(runtime["maxConnections"].get<int64_t>());
     }
     if (runtime.contains("keepAlive")) {
       config.keep_alive = runtime["keepAlive"].get<bool>();
+    }
+    if (runtime.contains("maxHostConnections")) {
+      config.max_host_connections = static_cast<size_t>(runtime["maxHostConnections"].get<int64_t>());
     }
   }
 
@@ -213,7 +216,7 @@ Core::doAction(Http::Request &request, const Darabonba::Json &runtime) {
       state.http_clients[hostKey] = newClient;
       client = std::move(newClient);
     } else {
-      // Update connection pool settings for existing client
+      // Update connection pool settings for existing client (thread-safe)
       it->second->setConnectionPoolConfig(pool_config);
       client = it->second;
     }
@@ -247,9 +250,17 @@ void Core::ClearHttpClient(const ConnectionPoolConfig &config) {
 // Function to clear all clients
 void Core::ClearAllHttpClients() {
   auto &state = GetSDKState();
-  std::lock_guard<std::mutex> lock(state.mutex);
-
-  state.http_clients.clear();
+  
+  // Move clients out of the map while holding the lock
+  // After move, state.http_clients is guaranteed to be empty (C++11 standard)
+  std::map<std::string, std::shared_ptr<Http::MCurlHttpClient>> clients;
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    clients = std::move(state.http_clients);
+  }
+  // Lock released here - clients will be destroyed outside the lock
+  // Each MCurlHttpClient destructor will call stop() and wait for the
+  // perform thread to finish, ensuring safe shutdown
 }
 
 // Function to get client count

--- a/src/darabonba/Core.cpp
+++ b/src/darabonba/Core.cpp
@@ -40,7 +40,8 @@ struct SDKState {
   std::atomic<bool> initialized{false};
   std::mutex mutex;
   // One HTTP client per host (scheme + host + port as key)
-  std::map<std::string, std::unique_ptr<Http::MCurlHttpClient>> http_clients;
+  // Using shared_ptr to allow releasing the lock before calling makeRequest
+  std::map<std::string, std::shared_ptr<Http::MCurlHttpClient>> http_clients;
 };
 
 SDKState& GetSDKState() {
@@ -190,31 +191,35 @@ Core::doAction(Http::Request &request, const Darabonba::Json &runtime) {
   }
   std::string hostKey = url.getHost();
 
-  std::lock_guard<std::mutex> lock(state.mutex);
-
-  // Extract connection pool configuration from runtime
-  ConnectionPoolConfig pool_config = getConnectionPoolConfig(request, runtime);
-
-  // Extract request-level configuration from runtime
+  // Extract request-level configuration from runtime (no lock needed)
   RequestConfig request_config = getRequestConfig(runtime);
 
-  // Check if we have a client for this host
-  auto it = state.http_clients.find(hostKey);
-  if (it == state.http_clients.end()) {
-    // Create new client for this host
-    auto newClient =
-        std::unique_ptr<Http::MCurlHttpClient>(new Http::MCurlHttpClient());
-    // Apply connection pool settings to the client
-    newClient->setConnectionPoolConfig(pool_config);
-    newClient->start();
-    it = state.http_clients.insert({hostKey, std::move(newClient)}).first;
-  } else {
-    // Update connection pool settings for existing client
-    // This allows config changes to take effect immediately
-    it->second->setConnectionPoolConfig(pool_config);
-  }
+  // Acquire lock only for client lookup/creation, release before makeRequest
+  std::shared_ptr<Http::MCurlHttpClient> client;
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
 
-  // Pass request-level configuration to be applied per-request
+    // Extract connection pool configuration from runtime
+    ConnectionPoolConfig pool_config = getConnectionPoolConfig(request, runtime);
+
+    // Check if we have a client for this host
+    auto it = state.http_clients.find(hostKey);
+    if (it == state.http_clients.end()) {
+      // Create new client for this host
+      auto newClient = std::make_shared<Http::MCurlHttpClient>();
+      // Apply connection pool settings to the client
+      newClient->setConnectionPoolConfig(pool_config);
+      newClient->start();
+      state.http_clients[hostKey] = newClient;
+      client = std::move(newClient);
+    } else {
+      // Update connection pool settings for existing client
+      it->second->setConnectionPoolConfig(pool_config);
+      client = it->second;
+    }
+  } // lock released here
+
+  // Build request-level runtime options (outside lock)
   Darabonba::Json request_runtime = Darabonba::Json::object();
   request_runtime["connectTimeout"] = request_config.connect_timeout_ms;
   request_runtime["readTimeout"] = request_config.read_timeout_ms;
@@ -223,7 +228,9 @@ Core::doAction(Http::Request &request, const Darabonba::Json &runtime) {
   request_runtime["httpsProxy"] = request_config.https_proxy;
   request_runtime["noProxy"] = request_config.no_proxy;
 
-  return it->second->makeRequest(request, request_runtime);
+  // makeRequest is now called without holding the global lock,
+  // allowing concurrent requests to different hosts
+  return client->makeRequest(request, request_runtime);
 }
 
 // Function to clear specific client configuration by ConnectionPoolConfig

--- a/src/darabonba/Core.cpp
+++ b/src/darabonba/Core.cpp
@@ -62,6 +62,9 @@ void EnsureInitialized() {
 }
 
 // Helper to extract connection pool config from request
+// Note: maxIdleConns and keepAlive are pool-level settings that should only be
+// configured at the Config level, not in RuntimeOptions. The values here come
+// from Client's Config, passed through the runtime JSON by the Client.
 ConnectionPoolConfig getConnectionPoolConfig(Http::Request &request,
                                              const Darabonba::Json &runtime) {
   ConnectionPoolConfig config;
@@ -79,21 +82,14 @@ ConnectionPoolConfig getConnectionPoolConfig(Http::Request &request,
     }
   }
 
-  // Extract connection pool configuration from runtime options if present
+  // Read connection pool settings from runtime (these are Config-level values
+  // passed by Client, not per-request RuntimeOptions)
   if (!runtime.is_null()) {
-    if (runtime.contains("maxConnections")) {
-      config.max_connections = runtime["maxConnections"].get<size_t>();
+    if (runtime.contains("maxIdleConns")) {
+      config.max_connections = static_cast<size_t>(runtime["maxIdleConns"].get<int64_t>());
     }
-    if (runtime.contains("connectionIdleTimeout")) {
-      config.connection_idle_timeout =
-          runtime["connectionIdleTimeout"].get<long>();
-    }
-    if (runtime.contains("pipelining")) {
-      config.pipelining = runtime["pipelining"].get<bool>();
-    }
-    if (runtime.contains("maxHostConnections")) {
-      config.max_host_connections =
-          runtime["maxHostConnections"].get<size_t>();
+    if (runtime.contains("keepAlive")) {
+      config.keep_alive = runtime["keepAlive"].get<bool>();
     }
   }
 
@@ -208,9 +204,14 @@ Core::doAction(Http::Request &request, const Darabonba::Json &runtime) {
     // Create new client for this host
     auto newClient =
         std::unique_ptr<Http::MCurlHttpClient>(new Http::MCurlHttpClient());
-    // TODO: Apply connection pool settings to the client using pool_config
+    // Apply connection pool settings to the client
+    newClient->setConnectionPoolConfig(pool_config);
     newClient->start();
     it = state.http_clients.insert({hostKey, std::move(newClient)}).first;
+  } else {
+    // Update connection pool settings for existing client
+    // This allows config changes to take effect immediately
+    it->second->setConnectionPoolConfig(pool_config);
   }
 
   // Pass request-level configuration to be applied per-request

--- a/src/darabonba/Stream.cpp
+++ b/src/darabonba/Stream.cpp
@@ -50,6 +50,10 @@ std::shared_ptr<IStream> Stream::toReadable(const Bytes &raw) {
   return std::make_shared<ISStream>(raw);
 }
 
+std::shared_ptr<IStream> Stream::toReadable(const Json &raw) {                                                                                                            
+  return std::make_shared<ISStream>(raw);                                                                                                                                 
+}
+
 std::shared_ptr<OStream> Stream::toWritable(const std::string &raw) {
   return std::make_shared<OSStream>(std::ostringstream(raw));
 }
@@ -59,7 +63,12 @@ std::shared_ptr<OStream> Stream::toWritable(const Bytes &raw) {
 }
 
 std::shared_ptr<IStream> Stream::readFromFilePath(const std::string &path) {
-  return std::shared_ptr<IStream>(new IFStream(path, std::ios::binary));
+  auto* stream = new IFStream(path, std::ios::binary);
+  if (!stream->isOpen()) {
+    delete stream;
+    throw Darabonba::DaraException("File not found or cannot be opened: " + path);
+  }
+  return std::shared_ptr<IStream>(stream);
 }
 
 std::shared_ptr<IStream> Stream::readFromBytes(Bytes &raw) {
@@ -90,7 +99,7 @@ size_t ISStream::read(char *buffer, size_t expectSize) {
 }
 
 size_t IFStream::read(char *buffer, size_t expectSize) {
-  if (std::ifstream::eof() || std::ifstream::bad())
+  if (std::ifstream::eof() || std::ifstream::bad() || std::ifstream::fail())
     return 0;
   auto realSize = std::ifstream::readsome(buffer, expectSize);
   if (realSize < 0)

--- a/src/darabonba/Stream.cpp
+++ b/src/darabonba/Stream.cpp
@@ -17,15 +17,6 @@ Bytes Stream::readAsBytes(std::shared_ptr<IStream> raw) {
   return result;
 }
 
-std::string Stream::cleanString(const std::string &str) {
-  std::string cleaned = str;
-  cleaned.erase(
-      std::remove_if(cleaned.begin(), cleaned.end(),
-                     [](unsigned char c) { return !std::isprint(c); }),
-      cleaned.end());
-  return cleaned;
-}
-
 std::string Stream::readAsString(std::shared_ptr<IStream> raw) {
   if (!raw)
     return "";
@@ -36,7 +27,7 @@ std::string Stream::readAsString(std::shared_ptr<IStream> raw) {
   while ((bytesRead = raw->read(buffer, sizeof(buffer))) > 0) {
     oss.write(buffer, bytesRead);
   }
-  return Stream::cleanString(oss.str());
+  return oss.str();
 }
 
 Json Stream::readAsJSON(std::shared_ptr<IStream> raw) {

--- a/src/darabonba/http/Curl.cpp
+++ b/src/darabonba/http/Curl.cpp
@@ -58,6 +58,7 @@ void setCurlRequestBody(CURL *easyHandle,
     }
 
     if (file != nullptr && !file->empty()) {
+      fileform->setFileField(file);
       part = curl_mime_addpart(mime);
       curl_mime_name(part, fileKey.c_str());
       curl_mime_filename(part, file->getFilename().c_str());

--- a/src/darabonba/http/Form.cpp
+++ b/src/darabonba/http/Form.cpp
@@ -19,7 +19,7 @@ std::string Form::toFormString(const Json &val) {
   }
   std::stringstream tmp;
   for (const auto &el : val.items()) {
-    tmp << Http::Query::encode(el.key()) << " = "
+    tmp << Http::Query::encode(el.key()) << "="
         << Http::Query::encode(el.value().is_string()
                                    ? el.value().get<std::string>()
                                    : el.value().dump())

--- a/src/darabonba/http/MCurlHttpClient.cpp
+++ b/src/darabonba/http/MCurlHttpClient.cpp
@@ -1,3 +1,4 @@
+#include <darabonba/Exception.hpp>
 #include <darabonba/http/Curl.hpp>
 #include <darabonba/http/MCurlHttpClient.hpp>
 #include <darabonba/http/MCurlResponse.hpp>
@@ -188,24 +189,53 @@ void MCurlHttpClient::perform() {
     while ((msg = curl_multi_info_read(mCurl_, &msgs_in_queue)) != nullptr) {
       if (msg->msg == CURLMSG_DONE) {
         auto easyHandle = msg->easy_handle;
-        auto curlStorage = std::move(runningCurl_[easyHandle]);
-        runningCurl_.erase(easyHandle);
 
-        auto body = dynamic_cast<MCurlResponseBody *>(
-            curlStorage->resp->getBody().get());
-        if (body) {
-          if (!body->getReady()) {
-            setResponseReady(curlStorage.get());
+        // Safe lookup - don't use operator[] which creates nullptr entries
+        auto it = runningCurl_.find(easyHandle);
+        if (it == runningCurl_.end()) {
+          // Handle not found - clean up and skip
+          curl_multi_remove_handle(mCurl_, easyHandle);
+          curl_easy_cleanup(easyHandle);
+          continue;
+        }
+        auto curlStorage = std::move(it->second);
+        runningCurl_.erase(it);
+
+        // Null check before accessing curlStorage
+        if (!curlStorage || !curlStorage->promise) {
+          if (nullptr != getenv("DEBUG")) {
+            std::cerr << "[DEBUG perform] Invalid curlStorage or promise for handle" << std::endl;
           }
-          // response body has been fully received
-          body->done_ = true;
-          body->doneCV_.notify_one();
+          curl_multi_remove_handle(mCurl_, easyHandle);
+          curl_easy_cleanup(easyHandle);
+          continue;
+        }
+
+        CURLcode curlResult = msg->data.result;
+        if (curlResult != CURLE_OK) {
+          if (nullptr != getenv("DEBUG")) {
+            std::cerr << "[DEBUG perform] Curl error: " << curl_easy_strerror(curlResult)
+                      << " (code: " << curlResult << ")" << std::endl;
+          }
+          curlStorage->promise->set_exception(
+              std::make_exception_ptr(Darabonba::ResponseException(
+                  "NetworkError",
+                  std::string("Curl error: ") + curl_easy_strerror(curlResult))));
+        } else {
+          auto body = dynamic_cast<MCurlResponseBody *>(
+              curlStorage->resp->getBody().get());
+          if (body) {
+            if (!body->getReady()) {
+              setResponseReady(curlStorage.get());
+            }
+            body->done_ = true;
+            body->doneCV_.notify_one();
+          }
         }
 
         if (curlStorage->reqBody) {
-          curlStorage->reqBody.reset(); // 使用智能指针的 reset 方法释放资源
+          curlStorage->reqBody.reset();
         }
-        // remove the easy hanle
         curl_multi_remove_handle(mCurl_, easyHandle);
         curl_easy_cleanup(easyHandle);
       } else {
@@ -215,7 +245,9 @@ void MCurlHttpClient::perform() {
   }
   // close the existing network connections.
   for (auto &p : runningCurl_) {
-    curl_slist_free_all(p.second->reqHeader);
+    if (p.second) {
+      curl_slist_free_all(p.second->reqHeader);
+    }
     curl_multi_remove_handle(mCurl_, p.first);
     curl_easy_cleanup(p.first);
   }
@@ -279,8 +311,10 @@ void MCurlHttpClient::clearQueue() {
   while (!reqQueue_.empty()) {
     auto storage = std::move(reqQueue_.front());
     reqQueue_.pop_front();
-    curl_slist_free_all(storage->reqHeader);
-    curl_easy_cleanup(storage->easyHandle);
+    if (storage) {
+      curl_slist_free_all(storage->reqHeader);
+      curl_easy_cleanup(storage->easyHandle);
+    }
   }
   reqQueue_.clear();
   continueReadingQueue_.clear();
@@ -299,6 +333,10 @@ bool MCurlHttpClient::addContinueReadingHandle(CURL *easyHandle) {
 }
 
 bool MCurlHttpClient::setResponseReady(CurlStorage *curlStorage) {
+  // Null pointer guard
+  if (!curlStorage) {
+    return false;
+  }
   // clear the request header
   curl_slist_free_all(curlStorage->reqHeader);
   curlStorage->reqHeader = nullptr;
@@ -320,6 +358,10 @@ bool MCurlHttpClient::setResponseReady(CurlStorage *curlStorage) {
 size_t MCurlHttpClient::recvBody(char *buffer, size_t size, size_t nmemb,
                                  void *userdata) {
   auto curlStorage = static_cast<CurlStorage *>(userdata);
+  // Null pointer guard
+  if (!curlStorage || !curlStorage->resp) {
+    return 0;
+  }
   auto body = curlStorage->resp->getBody();
   if (!body)
     return 0;

--- a/src/darabonba/http/MCurlHttpClient.cpp
+++ b/src/darabonba/http/MCurlHttpClient.cpp
@@ -30,6 +30,13 @@ MCurlHttpClient::makeRequest(const Request &request,
   curl_easy_setopt(easyHandle, CURLOPT_MAXCONNECTS,
                    static_cast<long>(config.max_connections));
 
+  // Set maximum connection age (curl 7.65.0+)
+  // This limits how long a connection can be reused
+#if LIBCURL_VERSION_NUM >= 0x074100
+  curl_easy_setopt(easyHandle, CURLOPT_MAXAGE_CONN,
+                   config.connection_idle_timeout);
+#endif
+
   // Apply keep-alive settings
   if (config.keep_alive) {
     curl_easy_setopt(easyHandle, CURLOPT_TCP_KEEPALIVE, 1L);

--- a/src/darabonba/http/MCurlHttpClient.cpp
+++ b/src/darabonba/http/MCurlHttpClient.cpp
@@ -201,11 +201,8 @@ void MCurlHttpClient::perform() {
         auto curlStorage = std::move(it->second);
         runningCurl_.erase(it);
 
-        // Null check before accessing curlStorage
-        if (!curlStorage || !curlStorage->promise) {
-          if (nullptr != getenv("DEBUG")) {
-            std::cerr << "[DEBUG perform] Invalid curlStorage or promise for handle" << std::endl;
-          }
+        // Null check - but we still need to set done_ and notify even if promise is null
+        if (!curlStorage) {
           curl_multi_remove_handle(mCurl_, easyHandle);
           curl_easy_cleanup(easyHandle);
           continue;
@@ -213,14 +210,12 @@ void MCurlHttpClient::perform() {
 
         CURLcode curlResult = msg->data.result;
         if (curlResult != CURLE_OK) {
-          if (nullptr != getenv("DEBUG")) {
-            std::cerr << "[DEBUG perform] Curl error: " << curl_easy_strerror(curlResult)
-                      << " (code: " << curlResult << ")" << std::endl;
+          if (curlStorage->promise) {
+            curlStorage->promise->set_exception(
+                std::make_exception_ptr(Darabonba::ResponseException(
+                    "NetworkError",
+                    std::string("Curl error: ") + curl_easy_strerror(curlResult))));
           }
-          curlStorage->promise->set_exception(
-              std::make_exception_ptr(Darabonba::ResponseException(
-                  "NetworkError",
-                  std::string("Curl error: ") + curl_easy_strerror(curlResult))));
         } else {
           auto body = dynamic_cast<MCurlResponseBody *>(
               curlStorage->resp->getBody().get());
@@ -229,7 +224,13 @@ void MCurlHttpClient::perform() {
               setResponseReady(curlStorage.get());
             }
             body->done_ = true;
+            body->streamCV_.notify_one();
             body->doneCV_.notify_one();
+          } else {
+            // This should never happen - log as error if DEBUG is enabled
+            if (nullptr != getenv("DEBUG")) {
+              std::cerr << "[ERROR perform] Response body is null!" << std::endl;
+            }
           }
         }
 
@@ -370,9 +371,6 @@ size_t MCurlHttpClient::recvBody(char *buffer, size_t size, size_t nmemb,
   }
   auto expectSize = size * nmemb;
   auto realSize = body->write(buffer, expectSize);
-  body->readableSize_ += realSize;
-  body->streamCV_.notify_one();
-
   if (!body->getReady()) {
     setResponseReady(curlStorage);
   }

--- a/src/darabonba/http/MCurlHttpClient.cpp
+++ b/src/darabonba/http/MCurlHttpClient.cpp
@@ -21,6 +21,19 @@ MCurlHttpClient::makeRequest(const Request &request,
     return promise.get_future();
   }
 
+  // Apply connection pool settings to easy handle
+  curl_easy_setopt(easyHandle, CURLOPT_MAXCONNECTS,
+                   static_cast<long>(poolConfig_.max_connections));
+
+  // Apply keep-alive settings
+  if (poolConfig_.keep_alive) {
+    curl_easy_setopt(easyHandle, CURLOPT_TCP_KEEPALIVE, 1L);
+    curl_easy_setopt(easyHandle, CURLOPT_TCP_KEEPIDLE, 60L);
+    curl_easy_setopt(easyHandle, CURLOPT_TCP_KEEPINTVL, 60L);
+    // Enable HTTP keep-alive
+    curl_easy_setopt(easyHandle, CURLOPT_FORBID_REUSE, 0L);
+  }
+
   if (!options.is_null()) {
     // process the runtime options
     // ssl
@@ -37,7 +50,7 @@ MCurlHttpClient::makeRequest(const Request &request,
     if (connectTimeout > 0) {
       curl_easy_setopt(easyHandle, CURLOPT_CONNECTTIMEOUT_MS, connectTimeout);
     }
-    long readTimeout = options.value("readTimeout", 0L);
+    long readTimeout = options.value("readTimeout", 10000L);
     if (readTimeout > 0) {
       curl_easy_setopt(easyHandle, CURLOPT_TIMEOUT_MS, readTimeout);
     }
@@ -193,9 +206,28 @@ void MCurlHttpClient::perform() {
 bool MCurlHttpClient::start() {
   if (!mCurl_ || running_)
     return false;
+  // Apply connection pool settings before starting
+  applyConnectionPoolSettings();
   running_ = true;
   performThread_ = std::thread(std::bind(&MCurlHttpClient::perform, this));
   return true;
+}
+
+void MCurlHttpClient::applyConnectionPoolSettings() {
+  if (!mCurl_)
+    return;
+
+  // Set maximum total connections in the multi handle
+  curl_multi_setopt(mCurl_, CURLMOPT_MAX_TOTAL_CONNECTIONS,
+                    static_cast<long>(poolConfig_.max_connections));
+
+  // Set maximum connections per host
+  curl_multi_setopt(mCurl_, CURLMOPT_MAX_HOST_CONNECTIONS,
+                    static_cast<long>(poolConfig_.max_host_connections));
+
+  // Enable/disable pipelining
+  curl_multi_setopt(mCurl_, CURLMOPT_PIPELINING,
+                    poolConfig_.pipelining ? 1L : 0L);
 }
 
 bool MCurlHttpClient::stop() {

--- a/src/darabonba/http/MCurlHttpClient.cpp
+++ b/src/darabonba/http/MCurlHttpClient.cpp
@@ -21,17 +21,25 @@ MCurlHttpClient::makeRequest(const Request &request,
     return promise.get_future();
   }
 
+  // Atomically load config to avoid race condition with setConnectionPoolConfig
+  // This ensures we use a consistent snapshot of the configuration
+  auto configPtr = std::atomic_load(&poolConfig_);
+  ConnectionPoolConfig config = configPtr ? *configPtr : ConnectionPoolConfig();
+
   // Apply connection pool settings to easy handle
   curl_easy_setopt(easyHandle, CURLOPT_MAXCONNECTS,
-                   static_cast<long>(poolConfig_.max_connections));
+                   static_cast<long>(config.max_connections));
 
   // Apply keep-alive settings
-  if (poolConfig_.keep_alive) {
+  if (config.keep_alive) {
     curl_easy_setopt(easyHandle, CURLOPT_TCP_KEEPALIVE, 1L);
     curl_easy_setopt(easyHandle, CURLOPT_TCP_KEEPIDLE, 60L);
     curl_easy_setopt(easyHandle, CURLOPT_TCP_KEEPINTVL, 60L);
     // Enable HTTP keep-alive
     curl_easy_setopt(easyHandle, CURLOPT_FORBID_REUSE, 0L);
+  } else {
+    // Disable connection reuse when keepAlive is false
+    curl_easy_setopt(easyHandle, CURLOPT_FORBID_REUSE, 1L);
   }
 
   if (!options.is_null()) {
@@ -124,6 +132,12 @@ MCurlHttpClient::makeRequest(const Request &request,
 
 void MCurlHttpClient::perform() {
   while (running_) {
+    // Apply config update if needed (before curl_multi_perform)
+    if (configNeedsUpdate_.load()) {
+      applyConnectionPoolSettings();
+      configNeedsUpdate_.store(false);
+    }
+
     if (reqQueueSize_) {
       decltype(reqQueue_) reqQueue;
       {
@@ -217,17 +231,24 @@ void MCurlHttpClient::applyConnectionPoolSettings() {
   if (!mCurl_)
     return;
 
+  // Atomically load config for thread-safe access
+  auto configPtr = std::atomic_load(&poolConfig_);
+  if (!configPtr)
+    return;
+
+  const ConnectionPoolConfig& config = *configPtr;
+
   // Set maximum total connections in the multi handle
   curl_multi_setopt(mCurl_, CURLMOPT_MAX_TOTAL_CONNECTIONS,
-                    static_cast<long>(poolConfig_.max_connections));
+                    static_cast<long>(config.max_connections));
 
   // Set maximum connections per host
   curl_multi_setopt(mCurl_, CURLMOPT_MAX_HOST_CONNECTIONS,
-                    static_cast<long>(poolConfig_.max_host_connections));
+                    static_cast<long>(config.max_host_connections));
 
   // Enable/disable pipelining
   curl_multi_setopt(mCurl_, CURLMOPT_PIPELINING,
-                    poolConfig_.pipelining ? 1L : 0L);
+                    config.pipelining ? 1L : 0L);
 }
 
 bool MCurlHttpClient::stop() {

--- a/src/darabonba/http/MCurlResponse.cpp
+++ b/src/darabonba/http/MCurlResponse.cpp
@@ -22,7 +22,7 @@ void MCurlResponseBody::waitForDone() {
   easyHandle_ = nullptr;
 }
 
-size_t MCurlResponseBody::read(char *buffer, size_t expectSize) {
+  size_t MCurlResponseBody::read(char *buffer, size_t expectSize) {
   if (done_ && readableSize_ == 0)
     return 0;
   size_t realSize = 0;
@@ -42,7 +42,7 @@ size_t MCurlResponseBody::read(char *buffer, size_t expectSize) {
       easyHandle_ = nullptr;
       return 0;
     }
-    // blocking wait
+    
     fetch();
     std::unique_lock<std::mutex> lock(streamMutex_);
     streamCV_.wait(
@@ -51,7 +51,7 @@ size_t MCurlResponseBody::read(char *buffer, size_t expectSize) {
 
   return realSize;
 }
-
+  
 bool MCurlResponseBody::fetch() {
   if (!easyHandle_ || !client_)
     return false;
@@ -60,11 +60,10 @@ bool MCurlResponseBody::fetch() {
 }
 
 size_t MCurlResponseBody::write(char *buffer, size_t expectSize) {
-  {
-    std::lock_guard<Lock::SpinLock> lock(bufferlock_);
-    buffer_.write(buffer, expectSize);
-  }
+  std::lock_guard<Lock::SpinLock> lock(bufferlock_);
+  buffer_.write(buffer, expectSize);
   readableSize_ += expectSize;
+  streamCV_.notify_one();  // 通知等待的消费者线程
   return expectSize;
 }
 

--- a/tests/src/darabonba/http/test_MCurlHttpClient.cpp
+++ b/tests/src/darabonba/http/test_MCurlHttpClient.cpp
@@ -1,0 +1,454 @@
+#include <darabonba/http/MCurlHttpClient.hpp>
+#include <darabonba/http/Request.hpp>
+#include <darabonba/Core.hpp>
+#include <darabonba/Runtime.hpp>
+#include <gtest/gtest.h>
+#include <thread>
+#include <chrono>
+#include <memory>
+
+using namespace Darabonba;
+using namespace Darabonba::Http;
+
+class MCurlHttpClientTest : public ::testing::Test {
+protected:
+  virtual void SetUp() override {}
+
+  virtual void TearDown() override {}
+};
+
+// ==================== MCurlHttpClient 生命周期测试 ====================
+
+TEST_F(MCurlHttpClientTest, CreateDestroy) {
+  MCurlHttpClient client;
+  // 析构函数应该正确清理资源
+}
+
+TEST_F(MCurlHttpClientTest, StartStop) {
+  MCurlHttpClient client;
+
+  EXPECT_TRUE(client.start());
+  EXPECT_FALSE(client.start());  // 已启动，再次启动返回 false
+  EXPECT_TRUE(client.stop());
+  EXPECT_FALSE(client.stop());   // 已停止，再次停止返回 false
+}
+
+TEST_F(MCurlHttpClientTest, StartStopSequence) {
+  MCurlHttpClient client;
+
+  EXPECT_TRUE(client.start());
+  EXPECT_TRUE(client.stop());
+}
+
+// ==================== ConnectionPoolConfig 测试 ====================
+
+TEST_F(MCurlHttpClientTest, DefaultConnectionPoolConfig) {
+  MCurlHttpClient client;
+  auto config = client.getConnectionPoolConfig();
+
+  EXPECT_EQ(config.max_connections, 128UL);
+  EXPECT_EQ(config.max_host_connections, 128UL);
+  EXPECT_EQ(config.connection_idle_timeout, 30L);
+  EXPECT_FALSE(config.pipelining);
+  EXPECT_TRUE(config.keep_alive);
+}
+
+TEST_F(MCurlHttpClientTest, SetConnectionPoolConfig) {
+  MCurlHttpClient client;
+
+  ConnectionPoolConfig config;
+  config.max_connections = 50;
+  config.max_host_connections = 10;
+  config.connection_idle_timeout = 60L;
+  config.pipelining = true;
+  config.keep_alive = false;
+
+  client.setConnectionPoolConfig(config);
+
+  auto retrieved = client.getConnectionPoolConfig();
+  EXPECT_EQ(retrieved.max_connections, 50UL);
+  EXPECT_EQ(retrieved.max_host_connections, 10UL);
+  EXPECT_EQ(retrieved.connection_idle_timeout, 60L);
+  EXPECT_TRUE(retrieved.pipelining);
+  EXPECT_FALSE(retrieved.keep_alive);
+}
+
+TEST_F(MCurlHttpClientTest, UpdateConnectionPoolConfigMultipleTimes) {
+  MCurlHttpClient client;
+
+  ConnectionPoolConfig config1;
+  config1.max_connections = 20;
+  client.setConnectionPoolConfig(config1);
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 20UL);
+
+  ConnectionPoolConfig config2;
+  config2.max_connections = 40;
+  client.setConnectionPoolConfig(config2);
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 40UL);
+}
+
+TEST_F(MCurlHttpClientTest, SetConfigBeforeStart) {
+  MCurlHttpClient client;
+
+  ConnectionPoolConfig config;
+  config.max_connections = 30;
+  client.setConnectionPoolConfig(config);
+
+  EXPECT_TRUE(client.start());
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 30UL);
+
+  EXPECT_TRUE(client.stop());
+}
+
+TEST_F(MCurlHttpClientTest, SetConfigAfterStart) {
+  MCurlHttpClient client;
+
+  EXPECT_TRUE(client.start());
+
+  ConnectionPoolConfig config;
+  config.max_connections = 25;
+  client.setConnectionPoolConfig(config);
+
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 25UL);
+
+  EXPECT_TRUE(client.stop());
+}
+
+// ==================== 并发配置更新测试 ====================
+
+TEST_F(MCurlHttpClientTest, ConcurrentConfigUpdate) {
+  MCurlHttpClient client;
+  client.start();
+
+  std::vector<std::thread> threads;
+  std::atomic<int> successCount{0};
+
+  for (int i = 0; i < 10; ++i) {
+    threads.emplace_back([&client, i, &successCount]() {
+      ConnectionPoolConfig config;
+      config.max_connections = static_cast<size_t>(10 + i);
+      client.setConnectionPoolConfig(config);
+      successCount++;
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  EXPECT_EQ(successCount.load(), 10);
+
+  client.stop();
+}
+
+// ==================== 网络请求测试 ====================
+
+TEST_F(MCurlHttpClientTest, MakeRequestToValidUrl) {
+  MCurlHttpClient client;
+  client.start();
+
+  try {
+    Request request(std::string("https://www.aliyun.com"));
+    request.getHeader()["User-Agent"] = "test-client";
+
+    Darabonba::Json options;
+    options["readTimeout"] = 10000;
+    options["connectTimeout"] = 5000;
+
+    auto future = client.makeRequest(request, options);
+
+    auto status = future.wait_for(std::chrono::seconds(15));
+    ASSERT_EQ(status, std::future_status::ready);
+
+    auto response = future.get();
+    if (response) {
+      EXPECT_GT(response->getStatusCode(), 0);
+      EXPECT_LT(response->getStatusCode(), 600);
+    }
+
+  } catch (const std::exception& e) {
+    std::cerr << "Network test skipped: " << e.what() << std::endl;
+  }
+
+  client.stop();
+}
+
+TEST_F(MCurlHttpClientTest, MakeRequestWithPostMethod) {
+  MCurlHttpClient client;
+  client.start();
+
+  try {
+    Request request(std::string("https://httpbin.org/post"));
+    request.setMethod(Request::Method::POST);
+    request.getHeader()["Content-Type"] = "application/json";
+    request.setBody(std::string("{\"test\": \"value\"}"));
+
+    Darabonba::Json options;
+    options["readTimeout"] = 15000;
+
+    auto future = client.makeRequest(request, options);
+
+    auto status = future.wait_for(std::chrono::seconds(20));
+    if (status == std::future_status::ready) {
+      auto response = future.get();
+      if (response) {
+        EXPECT_EQ(response->getStatusCode(), 200);
+      }
+    }
+
+  } catch (const std::exception& e) {
+    std::cerr << "Network test skipped: " << e.what() << std::endl;
+  }
+
+  client.stop();
+}
+
+TEST_F(MCurlHttpClientTest, MakeRequestWithInvalidUrl) {
+  MCurlHttpClient client;
+  client.start();
+
+  try {
+    Request request(std::string("https://invalid.nonexistent.domain.example/test"));
+
+    Darabonba::Json options;
+    options["readTimeout"] = 5000;
+    options["connectTimeout"] = 3000;
+
+    auto future = client.makeRequest(request, options);
+
+    auto status = future.wait_for(std::chrono::seconds(10));
+    ASSERT_EQ(status, std::future_status::ready);
+
+    // 无效域名应该抛出异常或返回错误
+    EXPECT_THROW({
+      auto response = future.get();
+    }, std::exception);
+
+  } catch (const std::exception& e) {
+    // 预期会抛出异常
+  }
+
+  client.stop();
+}
+
+// ==================== 多请求并发测试 ====================
+
+TEST_F(MCurlHttpClientTest, MultipleConcurrentRequests) {
+  MCurlHttpClient client;
+  client.start();
+
+  try {
+    std::vector<std::future<std::shared_ptr<MCurlResponse>>> futures;
+
+    for (int i = 0; i < 3; ++i) {
+      Request request(std::string("https://www.aliyun.com"));
+      Darabonba::Json options;
+      options["readTimeout"] = 10000;
+      futures.push_back(client.makeRequest(request, options));
+    }
+
+    for (auto& f : futures) {
+      auto status = f.wait_for(std::chrono::seconds(15));
+      if (status == std::future_status::ready) {
+        auto response = f.get();
+        if (response) {
+          EXPECT_GT(response->getStatusCode(), 0);
+        }
+      }
+    }
+
+  } catch (const std::exception& e) {
+    std::cerr << "Network test skipped: " << e.what() << std::endl;
+  }
+
+  client.stop();
+}
+
+// ==================== Keep-Alive 配置测试 ====================
+
+TEST_F(MCurlHttpClientTest, KeepAliveEnabled) {
+  MCurlHttpClient client;
+
+  ConnectionPoolConfig config;
+  config.keep_alive = true;
+  client.setConnectionPoolConfig(config);
+
+  EXPECT_TRUE(client.getConnectionPoolConfig().keep_alive);
+}
+
+TEST_F(MCurlHttpClientTest, KeepAliveDisabled) {
+  MCurlHttpClient client;
+
+  ConnectionPoolConfig config;
+  config.keep_alive = false;
+  client.setConnectionPoolConfig(config);
+
+  EXPECT_FALSE(client.getConnectionPoolConfig().keep_alive);
+}
+
+// ==================== 析构时资源清理测试 ====================
+
+TEST_F(MCurlHttpClientTest, DestructionDuringRequest) {
+  try {
+    MCurlHttpClient* client = new MCurlHttpClient();
+    client->start();
+
+    Request request(std::string("https://www.aliyun.com"));
+    Darabonba::Json options;
+    options["readTimeout"] = 10000;
+
+    auto future = client->makeRequest(request, options);
+
+    // 在请求进行中销毁客户端
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    delete client;
+
+    // 应该不会崩溃
+    EXPECT_TRUE(true);
+
+  } catch (const std::exception& e) {
+    std::cerr << "Test exception: " << e.what() << std::endl;
+  }
+}
+
+// ==================== 边界条件测试 ====================
+
+TEST_F(MCurlHttpClientTest, ZeroConnections) {
+  MCurlHttpClient client;
+
+  ConnectionPoolConfig config;
+  config.max_connections = 0;
+  client.setConnectionPoolConfig(config);
+
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 0UL);
+}
+
+TEST_F(MCurlHttpClientTest, LargeConnections) {
+  MCurlHttpClient client;
+
+  ConnectionPoolConfig config;
+  config.max_connections = 10000;
+  client.setConnectionPoolConfig(config);
+
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 10000UL);
+}
+
+// ==================== 错误处理测试 ====================
+// 这些测试验证最新的代码改动：perform() 中的 null promise 检查
+
+TEST_F(MCurlHttpClientTest, EmptyRequestHandling) {
+  MCurlHttpClient client;
+  client.start();
+
+  try {
+    // 使用无效 URL 测试错误处理
+    Request request(std::string(""));
+
+    Darabonba::Json options;
+
+    auto future = client.makeRequest(request, options);
+
+    auto status = future.wait_for(std::chrono::seconds(5));
+    if (status == std::future_status::ready) {
+      // 应该抛出异常或返回错误
+      EXPECT_THROW({
+        auto response = future.get();
+      }, std::exception);
+    }
+
+  } catch (const std::exception& e) {
+    // 预期会抛出异常
+  }
+
+  client.stop();
+}
+
+// ==================== 流式响应测试 ====================
+
+TEST_F(MCurlHttpClientTest, StreamResponseBody) {
+  MCurlHttpClient client;
+  client.start();
+
+  try {
+    Request request(std::string("https://www.aliyun.com"));
+
+    Darabonba::Json options;
+    options["readTimeout"] = 15000;
+
+    auto future = client.makeRequest(request, options);
+
+    auto status = future.wait_for(std::chrono::seconds(15));
+    if (status == std::future_status::ready) {
+      auto response = future.get();
+      if (response && response->getBody()) {
+        auto body = response->getBody();
+
+        // 测试流式读取
+        char buffer[1024];
+        size_t totalRead = 0;
+        size_t bytesRead;
+
+        while ((bytesRead = body->read(buffer, sizeof(buffer))) > 0) {
+          totalRead += bytesRead;
+        }
+
+        EXPECT_GT(totalRead, 0u);
+      }
+    }
+
+  } catch (const std::exception& e) {
+    std::cerr << "Network test skipped: " << e.what() << std::endl;
+  }
+
+  client.stop();
+}
+
+// ==================== 响应体并发读取测试 ====================
+
+TEST_F(MCurlHttpClientTest, ConcurrentResponseBodyRead) {
+  MCurlHttpClient client;
+  client.start();
+
+  try {
+    Request request(std::string("https://www.aliyun.com"));
+
+    Darabonba::Json options;
+    options["readTimeout"] = 15000;
+
+    auto future = client.makeRequest(request, options);
+
+    auto status = future.wait_for(std::chrono::seconds(15));
+    if (status == std::future_status::ready) {
+      auto response = future.get();
+      if (response && response->getBody()) {
+        auto body = response->getBody();
+
+        std::atomic<size_t> totalRead{0};
+        std::vector<std::thread> readers;
+
+        // 启动多个读线程测试并发安全性
+        for (int i = 0; i < 2; ++i) {
+          readers.emplace_back([&body, &totalRead]() {
+            char buffer[512];
+            size_t bytesRead;
+            while ((bytesRead = body->read(buffer, sizeof(buffer))) > 0) {
+              totalRead += bytesRead;
+            }
+          });
+        }
+
+        for (auto& t : readers) {
+          t.join();
+        }
+
+        // 应该成功读取数据
+        EXPECT_GE(totalRead.load(), 0u);
+      }
+    }
+
+  } catch (const std::exception& e) {
+    std::cerr << "Network test skipped: " << e.what() << std::endl;
+  }
+
+  client.stop();
+}

--- a/tests/src/darabonba/http/test_MCurlHttpClient.cpp
+++ b/tests/src/darabonba/http/test_MCurlHttpClient.cpp
@@ -224,7 +224,7 @@ TEST_F(MCurlHttpClientTest, MakeRequestWithInvalidUrl) {
       auto response = future.get();
     }, std::exception);
 
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     // 预期会抛出异常
   }
 
@@ -356,7 +356,7 @@ TEST_F(MCurlHttpClientTest, EmptyRequestHandling) {
       }, std::exception);
     }
 
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     // 预期会抛出异常
   }
 

--- a/tests/src/darabonba/http/test_MCurlResponseBody.cpp
+++ b/tests/src/darabonba/http/test_MCurlResponseBody.cpp
@@ -151,8 +151,8 @@ TEST_F(MCurlResponseBodyTest, ConcurrentWriteAndRead) {
 // 测试多次 write 正确更新 readableSize
 TEST_F(MCurlResponseBodyTest, ConcurrentMultipleWrites) {
   TestableMCurlResponseBody body;
-  const int numWriters = 3;
-  const int writesPerThread = 10;
+  static constexpr int numWriters = 3;
+  static constexpr int writesPerThread = 10;
   std::vector<std::thread> writers;
   std::atomic<int> totalWritten{0};
 
@@ -279,7 +279,7 @@ TEST_F(MCurlResponseBodyTest, StressTestReadWrite) {
       char data[10];
       snprintf(data, sizeof(data), "msg%03d", i);
       body.write(data, strlen(data));
-      totalWritten += strlen(data);
+      totalWritten += static_cast<int>(strlen(data));
     }
     doneWriting = true;
     body.done_ = true;
@@ -294,7 +294,7 @@ TEST_F(MCurlResponseBodyTest, StressTestReadWrite) {
       if (bytesRead == 0 && body.getDone()) {
         break;
       }
-      totalRead += bytesRead;
+      totalRead += static_cast<int>(bytesRead);
     }
   });
 

--- a/tests/src/darabonba/http/test_MCurlResponseBody.cpp
+++ b/tests/src/darabonba/http/test_MCurlResponseBody.cpp
@@ -1,0 +1,377 @@
+#include <darabonba/http/MCurlResponse.hpp>
+#include <darabonba/http/MCurlHttpClient.hpp>
+#include <darabonba/Core.hpp>
+#include <gtest/gtest.h>
+#include <thread>
+#include <chrono>
+#include <vector>
+#include <atomic>
+
+using namespace Darabonba;
+using namespace Darabonba::Http;
+
+// 测试用的子类，暴露 protected 成员用于测试
+class TestableMCurlResponseBody : public MCurlResponseBody {
+public:
+  using MCurlResponseBody::done_;
+  using MCurlResponseBody::streamCV_;
+  using MCurlResponseBody::doneCV_;
+  using MCurlResponseBody::ready_;
+};
+
+class MCurlResponseBodyTest : public ::testing::Test {
+protected:
+  virtual void SetUp() override {}
+
+  virtual void TearDown() override {}
+};
+
+// ==================== MCurlResponseBody 基础测试 ====================
+
+TEST_F(MCurlResponseBodyTest, InitialState) {
+  TestableMCurlResponseBody body;
+
+  EXPECT_FALSE(body.getDone());
+  EXPECT_FALSE(body.getReady());
+  EXPECT_EQ(body.getReadableSize(), 0u);
+}
+
+TEST_F(MCurlResponseBodyTest, WriteIncreasesReadableSize) {
+  TestableMCurlResponseBody body;
+
+  char data[] = "Hello, World!";
+  size_t written = body.write(data, strlen(data));
+
+  EXPECT_EQ(written, strlen(data));
+  EXPECT_EQ(body.getReadableSize(), strlen(data));
+}
+
+TEST_F(MCurlResponseBodyTest, WriteMultipleTimes) {
+  TestableMCurlResponseBody body;
+
+  char data1[] = "Hello";
+  char data2[] = ", ";
+  char data3[] = "World!";
+
+  body.write(data1, strlen(data1));
+  EXPECT_EQ(body.getReadableSize(), 5u);
+
+  body.write(data2, strlen(data2));
+  EXPECT_EQ(body.getReadableSize(), 7u);
+
+  body.write(data3, strlen(data3));
+  EXPECT_EQ(body.getReadableSize(), 13u);
+}
+
+TEST_F(MCurlResponseBodyTest, ReadFromEmptyBody) {
+  TestableMCurlResponseBody body;
+  body.done_ = true;  // 标记为完成
+
+  char buffer[100];
+  size_t bytesRead = body.read(buffer, sizeof(buffer));
+
+  EXPECT_EQ(bytesRead, 0u);
+}
+
+TEST_F(MCurlResponseBodyTest, WriteAndRead) {
+  TestableMCurlResponseBody body;
+
+  char data[] = "Test Data";
+  body.write(data, strlen(data));
+
+  char buffer[100] = {0};
+  size_t bytesRead = body.read(buffer, sizeof(buffer));
+
+  EXPECT_EQ(bytesRead, strlen(data));
+  EXPECT_EQ(std::string(buffer, bytesRead), "Test Data");
+  EXPECT_EQ(body.getReadableSize(), 0u);
+}
+
+TEST_F(MCurlResponseBodyTest, ReadPartialData) {
+  TestableMCurlResponseBody body;
+
+  char data[] = "Hello, World!";
+  body.write(data, strlen(data));
+
+  char buffer[5] = {0};
+  size_t bytesRead = body.read(buffer, sizeof(buffer));
+
+  EXPECT_EQ(bytesRead, 5u);
+  EXPECT_EQ(std::string(buffer, bytesRead), "Hello");
+  EXPECT_EQ(body.getReadableSize(), 8u);  // 剩余数据
+}
+
+TEST_F(MCurlResponseBodyTest, IsFinished) {
+  TestableMCurlResponseBody body;
+
+  EXPECT_FALSE(body.isFinished());
+
+  body.done_ = true;
+  EXPECT_TRUE(body.isFinished());
+
+  char data[] = "data";
+  body.write(data, strlen(data));
+  EXPECT_FALSE(body.isFinished());  // 还有数据未读
+
+  char buffer[100];
+  body.read(buffer, sizeof(buffer));
+  EXPECT_TRUE(body.isFinished());  // 数据已读完且 done_ 为 true
+}
+
+// ==================== 并发测试 ====================
+
+// 测试 write() 方法正确通知 streamCV_
+TEST_F(MCurlResponseBodyTest, ConcurrentWriteAndRead) {
+  TestableMCurlResponseBody body;
+  std::atomic<bool> readCompleted{false};
+  std::atomic<bool> writeCompleted{false};
+
+  // 读线程 - 等待数据
+  std::thread readThread([&]() {
+    char buffer[100] = {0};
+    size_t bytesRead = body.read(buffer, sizeof(buffer));
+    if (bytesRead > 0) {
+      readCompleted = true;
+    }
+  });
+
+  // 稍微延迟后写入数据
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  char data[] = "Async Data";
+  body.write(data, strlen(data));
+  writeCompleted = true;
+
+  readThread.join();
+
+  EXPECT_TRUE(writeCompleted);
+  EXPECT_TRUE(readCompleted);
+}
+
+// 测试多次 write 正确更新 readableSize
+TEST_F(MCurlResponseBodyTest, ConcurrentMultipleWrites) {
+  TestableMCurlResponseBody body;
+  const int numWriters = 3;
+  const int writesPerThread = 10;
+  std::vector<std::thread> writers;
+  std::atomic<int> totalWritten{0};
+
+  for (int i = 0; i < numWriters; ++i) {
+    writers.emplace_back([&body, i, &totalWritten]() {
+      for (int j = 0; j < writesPerThread; ++j) {
+        char data[2] = {static_cast<char>('A' + i), static_cast<char>('0' + j)};
+        body.write(data, 2);
+        totalWritten += 2;
+      }
+    });
+  }
+
+  for (auto& t : writers) {
+    t.join();
+  }
+
+  EXPECT_EQ(body.getReadableSize(), static_cast<size_t>(numWriters * writesPerThread * 2));
+}
+
+// 测试 done_ 标志和通知机制
+TEST_F(MCurlResponseBodyTest, DoneFlagWithConcurrentRead) {
+  TestableMCurlResponseBody body;
+  std::atomic<bool> readReturned{false};
+
+  // 读线程 - 应该在 done_ 设置后返回
+  std::thread readThread([&]() {
+    char buffer[100] = {0};
+    body.read(buffer, sizeof(buffer));
+    readReturned = true;
+  });
+
+  // 稍微延迟后设置 done_
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  body.done_ = true;
+  body.streamCV_.notify_one();
+
+  readThread.join();
+
+  EXPECT_TRUE(readReturned);
+}
+
+// 测试 waitForDone 方法 - 需要有效的 client 和 easyHandle
+// 简化测试：只测试 done_ 标志和条件变量
+TEST_F(MCurlResponseBodyTest, DoneFlagCanBeSet) {
+  TestableMCurlResponseBody body;
+  EXPECT_FALSE(body.getDone());
+  body.done_ = true;
+  EXPECT_TRUE(body.getDone());
+}
+
+// ==================== 边界条件测试 ====================
+
+TEST_F(MCurlResponseBodyTest, WriteEmptyData) {
+  TestableMCurlResponseBody body;
+
+  char data[] = "";
+  size_t written = body.write(data, 0);
+
+  EXPECT_EQ(written, 0u);
+  EXPECT_EQ(body.getReadableSize(), 0u);
+}
+
+TEST_F(MCurlResponseBodyTest, WriteLargeData) {
+  TestableMCurlResponseBody body;
+
+  std::vector<char> largeData(1024 * 1024, 'X');  // 1MB
+  size_t written = body.write(largeData.data(), largeData.size());
+
+  EXPECT_EQ(written, largeData.size());
+  EXPECT_EQ(body.getReadableSize(), largeData.size());
+}
+
+TEST_F(MCurlResponseBodyTest, MaxSizeDefault) {
+  TestableMCurlResponseBody body;
+  EXPECT_EQ(body.getMaxSize(), 10u * 1024u * 1024u);  // 10MB
+}
+
+TEST_F(MCurlResponseBodyTest, ReadAfterMultipleWrites) {
+  TestableMCurlResponseBody body;
+
+  char data1[] = "Part1";
+  char data2[] = "Part2";
+  char data3[] = "Part3";
+
+  body.write(data1, strlen(data1));
+  body.write(data2, strlen(data2));
+  body.write(data3, strlen(data3));
+
+  char buffer[100] = {0};
+  size_t bytesRead = body.read(buffer, sizeof(buffer));
+
+  EXPECT_EQ(bytesRead, 15u);
+  EXPECT_EQ(std::string(buffer, bytesRead), "Part1Part2Part3");
+}
+
+// ==================== fetch 方法测试 ====================
+
+TEST_F(MCurlResponseBodyTest, FetchWithoutClient) {
+  TestableMCurlResponseBody body;
+  // 没有 client 和 easyHandle 时应该返回 false
+  EXPECT_FALSE(body.fetch());
+}
+
+// ==================== getReady/setReady 测试 ====================
+
+TEST_F(MCurlResponseBodyTest, ReadyFlagDefaultFalse) {
+  TestableMCurlResponseBody body;
+  EXPECT_FALSE(body.getReady());
+}
+
+// ==================== 并发读写压力测试 ====================
+
+TEST_F(MCurlResponseBodyTest, StressTestReadWrite) {
+  TestableMCurlResponseBody body;
+  const int iterations = 100;
+  std::atomic<int> totalRead{0};
+  std::atomic<int> totalWritten{0};
+  std::atomic<bool> doneWriting{false};
+
+  // 写线程
+  std::thread writeThread([&]() {
+    for (int i = 0; i < iterations; ++i) {
+      char data[10];
+      snprintf(data, sizeof(data), "msg%03d", i);
+      body.write(data, strlen(data));
+      totalWritten += strlen(data);
+    }
+    doneWriting = true;
+    body.done_ = true;
+    body.streamCV_.notify_one();
+  });
+
+  // 读线程
+  std::thread readThread([&]() {
+    while (true) {
+      char buffer[100];
+      size_t bytesRead = body.read(buffer, sizeof(buffer));
+      if (bytesRead == 0 && body.getDone()) {
+        break;
+      }
+      totalRead += bytesRead;
+    }
+  });
+
+  writeThread.join();
+  readThread.join();
+
+  EXPECT_EQ(totalRead.load(), totalWritten.load());
+}
+
+// ==================== 通知机制验证测试 ====================
+// 这些测试验证最新的代码改动：write() 正确通知 streamCV_
+
+TEST_F(MCurlResponseBodyTest, WriteNotifiesStreamCV) {
+  TestableMCurlResponseBody body;
+  std::atomic<bool> dataAvailable{false};
+  std::atomic<bool> readStarted{false};
+
+  // 读线程 - 应该在 write 后被通知
+  std::thread readThread([&]() {
+    readStarted = true;
+    char buffer[100];
+    // read() 会等待 streamCV_ 通知
+    size_t bytesRead = body.read(buffer, sizeof(buffer));
+    if (bytesRead > 0) {
+      dataAvailable = true;
+    }
+  });
+
+  // 等待读线程启动
+  while (!readStarted.load()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  // 稍微延迟后写入数据 - write() 应该通知 streamCV_
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  char data[] = "test";
+  body.write(data, strlen(data));
+
+  readThread.join();
+
+  EXPECT_TRUE(dataAvailable);
+}
+
+TEST_F(MCurlResponseBodyTest, MultipleWritesNotifyMultipleReads) {
+  TestableMCurlResponseBody body;
+  const int numOperations = 5;
+  std::atomic<int> readsCompleted{0};
+
+  // 写入初始数据
+  char initialData[] = "initial";
+  body.write(initialData, strlen(initialData));
+
+  // 读线程
+  std::thread readThread([&]() {
+    for (int i = 0; i < numOperations; ++i) {
+      char buffer[100];
+      size_t bytesRead = body.read(buffer, sizeof(buffer));
+      if (bytesRead > 0) {
+        readsCompleted++;
+      }
+    }
+  });
+
+  // 主线程继续写入
+  for (int i = 0; i < numOperations - 1; ++i) {
+    char data[20];
+    snprintf(data, sizeof(data), "data%d", i);
+    body.write(data, strlen(data));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  // 标记完成
+  body.done_ = true;
+  body.streamCV_.notify_one();
+
+  readThread.join();
+
+  // 应该成功读取多次
+  EXPECT_GT(readsCompleted.load(), 0);
+}

--- a/tests/src/darabonba/test_Core.cpp
+++ b/tests/src/darabonba/test_Core.cpp
@@ -979,6 +979,6 @@ TEST_F(CoreTest, RequestConfigZeroTimeout) {
 TEST_F(CoreTest, RequestConfigDefaultTimeoutValues) {
   RequestConfig config;
   EXPECT_EQ(config.connect_timeout_ms, 5000LL);
-  EXPECT_EQ(config.read_timeout_ms, 0LL);
+  EXPECT_EQ(config.read_timeout_ms, 10000LL);  // 默认 10 秒
   EXPECT_FALSE(config.ignore_ssl);
 }

--- a/tests/src/darabonba/test_Core.cpp
+++ b/tests/src/darabonba/test_Core.cpp
@@ -982,3 +982,315 @@ TEST_F(CoreTest, RequestConfigDefaultTimeoutValues) {
   EXPECT_EQ(config.read_timeout_ms, 10000LL);  // 默认 10 秒
   EXPECT_FALSE(config.ignore_ssl);
 }
+
+// ==================== fromMap 模板函数测试 ====================
+
+// 测试用的 Model 类
+class FromMapTestModel : public Darabonba::Model {
+public:
+  std::shared_ptr<std::string> name_;
+  std::shared_ptr<int32_t> count_;
+  std::shared_ptr<bool> enabled_;
+
+  friend void from_json(const Darabonba::Json& j, FromMapTestModel& obj) {
+    DARABONBA_PTR_FROM_JSON(name, name_);
+    DARABONBA_PTR_FROM_JSON(count, count_);
+    DARABONBA_PTR_FROM_JSON(enabled, enabled_);
+  }
+
+  friend void to_json(Darabonba::Json& j, const FromMapTestModel& obj) {
+    DARABONBA_PTR_TO_JSON(name, name_);
+    DARABONBA_PTR_TO_JSON(count, count_);
+    DARABONBA_PTR_TO_JSON(enabled, enabled_);
+  }
+
+  Json toMap() const override {
+    Json j;
+    to_json(j, *this);
+    return j;
+  }
+
+  void fromMap(const Json& j) override {
+    from_json(j, *this);
+  }
+
+  void validate() const override {}
+  bool empty() const override { return !name_ && !count_ && !enabled_; }
+};
+
+TEST_F(CoreTest, FromMapBasicUsage) {
+  Json j;
+  j["name"] = "test";
+  j["count"] = 42;
+  j["enabled"] = true;
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.name_ != nullptr);
+  EXPECT_EQ(*model.name_, "test");
+  EXPECT_TRUE(model.count_ != nullptr);
+  EXPECT_EQ(*model.count_, 42);
+  EXPECT_TRUE(model.enabled_ != nullptr);
+  EXPECT_TRUE(*model.enabled_);
+}
+
+TEST_F(CoreTest, FromMapWithNullValues) {
+  Json j;
+  j["name"] = nullptr;
+  j["count"] = nullptr;
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.name_ == nullptr);
+  EXPECT_TRUE(model.count_ == nullptr);
+}
+
+TEST_F(CoreTest, FromMapWithMissingKeys) {
+  Json j;  // 空 JSON
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.empty());
+}
+
+TEST_F(CoreTest, FromMapTypeConversionStringToInt) {
+  Json j;
+  j["name"] = "convert_test";
+  j["count"] = "100";  // 字符串形式的数字
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.count_ != nullptr);
+  EXPECT_EQ(*model.count_, 100);
+}
+
+TEST_F(CoreTest, FromMapTypeConversionBoolToInt) {
+  Json j;
+  j["count"] = true;  // bool -> int
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.count_ != nullptr);
+  EXPECT_EQ(*model.count_, 1);
+}
+
+TEST_F(CoreTest, FromMapTypeConversionIntToString) {
+  Json j;
+  j["name"] = 12345;  // int -> string
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.name_ != nullptr);
+  EXPECT_EQ(*model.name_, "12345");
+}
+
+TEST_F(CoreTest, FromMapTypeConversionBoolToString) {
+  Json j;
+  j["name"] = true;  // bool -> string
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.name_ != nullptr);
+  EXPECT_EQ(*model.name_, "true");
+}
+
+TEST_F(CoreTest, FromMapTypeConversionStringToBool) {
+  Json j;
+  j["enabled"] = "true";  // string -> bool
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.enabled_ != nullptr);
+  EXPECT_TRUE(*model.enabled_);
+
+  j["enabled"] = "FALSE";
+  model = Darabonba::fromMap<FromMapTestModel>(j);
+  EXPECT_FALSE(*model.enabled_);
+
+  j["enabled"] = "1";
+  model = Darabonba::fromMap<FromMapTestModel>(j);
+  EXPECT_TRUE(*model.enabled_);
+}
+
+TEST_F(CoreTest, FromMapNullToInt) {
+  Json j;
+  j["count"] = nullptr;
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.count_ == nullptr);
+}
+
+TEST_F(CoreTest, FromMapNullToBool) {
+  Json j;
+  j["enabled"] = nullptr;
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.enabled_ == nullptr);
+}
+
+TEST_F(CoreTest, FromMapNullToString) {
+  Json j;
+  j["name"] = nullptr;
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.name_ == nullptr);
+}
+
+TEST_F(CoreTest, FromMapFloatToString) {
+  Json j;
+  j["name"] = 3.14;  // float -> string
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+
+  EXPECT_TRUE(model.name_ != nullptr);
+  // 浮点数转字符串
+  EXPECT_FALSE(model.name_->empty());
+}
+
+TEST_F(CoreTest, FromMapIntToBool) {
+  Json j;
+  j["enabled"] = 1;  // int -> bool
+
+  FromMapTestModel model = Darabonba::fromMap<FromMapTestModel>(j);
+  EXPECT_TRUE(*model.enabled_);
+
+  j["enabled"] = 0;
+  model = Darabonba::fromMap<FromMapTestModel>(j);
+  EXPECT_FALSE(*model.enabled_);
+}
+
+// ==================== safe_convert 详细测试 ====================
+
+TEST_F(CoreTest, SafeConvertStringToString) {
+  Json j = "hello";
+  std::string result = Darabonba::detail::safe_convert<std::string>(j);
+  EXPECT_EQ(result, "hello");
+}
+
+TEST_F(CoreTest, SafeConvertIntToString) {
+  Json j = 42;
+  std::string result = Darabonba::detail::safe_convert<std::string>(j);
+  EXPECT_EQ(result, "42");
+}
+
+TEST_F(CoreTest, SafeConvertBoolToString) {
+  Json j = true;
+  std::string result = Darabonba::detail::safe_convert<std::string>(j);
+  EXPECT_EQ(result, "true");
+
+  j = false;
+  result = Darabonba::detail::safe_convert<std::string>(j);
+  EXPECT_EQ(result, "false");
+}
+
+TEST_F(CoreTest, SafeConvertNullToString) {
+  Json j = nullptr;
+  std::string result = Darabonba::detail::safe_convert<std::string>(j);
+  EXPECT_EQ(result, "");
+}
+
+TEST_F(CoreTest, SafeConvertStringToInt32) {
+  Json j = "123";
+  int32_t result = Darabonba::detail::safe_convert<int32_t>(j);
+  EXPECT_EQ(result, 123);
+}
+
+TEST_F(CoreTest, SafeConvertBoolToInt32) {
+  Json j = true;
+  int32_t result = Darabonba::detail::safe_convert<int32_t>(j);
+  EXPECT_EQ(result, 1);
+
+  j = false;
+  result = Darabonba::detail::safe_convert<int32_t>(j);
+  EXPECT_EQ(result, 0);
+}
+
+TEST_F(CoreTest, SafeConvertNullToInt32) {
+  Json j = nullptr;
+  int32_t result = Darabonba::detail::safe_convert<int32_t>(j);
+  EXPECT_EQ(result, 0);
+}
+
+TEST_F(CoreTest, SafeConvertStringToInt64) {
+  Json j = "9223372036854775807";  // INT64_MAX
+  int64_t result = Darabonba::detail::safe_convert<int64_t>(j);
+  EXPECT_EQ(result, INT64_MAX);
+}
+
+TEST_F(CoreTest, SafeConvertBoolToInt64) {
+  Json j = true;
+  int64_t result = Darabonba::detail::safe_convert<int64_t>(j);
+  EXPECT_EQ(result, 1);
+}
+
+TEST_F(CoreTest, SafeConvertNullToInt64) {
+  Json j = nullptr;
+  int64_t result = Darabonba::detail::safe_convert<int64_t>(j);
+  EXPECT_EQ(result, 0);
+}
+
+TEST_F(CoreTest, SafeConvertStringToBool) {
+  Json j = "true";
+  bool result = Darabonba::detail::safe_convert<bool>(j);
+  EXPECT_TRUE(result);
+
+  j = "TRUE";
+  result = Darabonba::detail::safe_convert<bool>(j);
+  EXPECT_TRUE(result);
+
+  j = "1";
+  result = Darabonba::detail::safe_convert<bool>(j);
+  EXPECT_TRUE(result);
+
+  j = "false";
+  result = Darabonba::detail::safe_convert<bool>(j);
+  EXPECT_FALSE(result);
+
+  j = "0";
+  result = Darabonba::detail::safe_convert<bool>(j);
+  EXPECT_FALSE(result);
+
+  j = "anything";
+  result = Darabonba::detail::safe_convert<bool>(j);
+  EXPECT_FALSE(result);
+}
+
+TEST_F(CoreTest, SafeConvertIntToBool) {
+  Json j = 1;
+  bool result = Darabonba::detail::safe_convert<bool>(j);
+  EXPECT_TRUE(result);
+
+  j = 0;
+  result = Darabonba::detail::safe_convert<bool>(j);
+  EXPECT_FALSE(result);
+
+  j = -1;
+  result = Darabonba::detail::safe_convert<bool>(j);
+  EXPECT_TRUE(result);  // 非0即为true
+}
+
+TEST_F(CoreTest, SafeConvertNullToBool) {
+  Json j = nullptr;
+  bool result = Darabonba::detail::safe_convert<bool>(j);
+  EXPECT_FALSE(result);
+}
+
+TEST_F(CoreTest, SafeConvertInvalidStringToInt32Throws) {
+  Json j = "not_a_number";
+  EXPECT_THROW(Darabonba::detail::safe_convert<int32_t>(j), std::runtime_error);
+}
+
+TEST_F(CoreTest, SafeConvertInvalidStringToInt64Throws) {
+  Json j = "not_a_number";
+  EXPECT_THROW(Darabonba::detail::safe_convert<int64_t>(j), std::runtime_error);
+}
+
+TEST_F(CoreTest, SafeConvertObjectToString) {
+  Json j = {{"key", "value"}};
+  std::string result = Darabonba::detail::safe_convert<std::string>(j);
+  // 对象转字符串应该返回 JSON dump
+  EXPECT_FALSE(result.empty());
+}

--- a/tests/src/darabonba/test_Core.cpp
+++ b/tests/src/darabonba/test_Core.cpp
@@ -313,9 +313,9 @@ TEST_F(CoreTest, DoActionWithQueryParams) {
 // ==================== ConnectionPoolConfig 测试 ====================
 TEST_F(CoreTest, ConnectionPoolConfigDefaultValues) {
   ConnectionPoolConfig config;
-  EXPECT_EQ(config.max_connections, 5UL);
-  EXPECT_EQ(config.max_host_connections, 2UL);
-  EXPECT_EQ(config.connection_idle_timeout, 300L);
+  EXPECT_EQ(config.max_connections, 128UL);
+  EXPECT_EQ(config.max_host_connections, 128UL);
+  EXPECT_EQ(config.connection_idle_timeout, 30L);
   EXPECT_FALSE(config.pipelining);
   EXPECT_TRUE(config.keep_alive);
 }
@@ -465,7 +465,7 @@ TEST_F(CoreTest, ConnectionPoolConfigCopy) {
 // ==================== MCurlHttpClient 详细测试 ====================
 TEST_F(CoreTest, MCurlHttpClientDefaultConnectionPoolConfig) {
   Http::MCurlHttpClient client;
-  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 5UL);
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 128UL);
   EXPECT_TRUE(client.getConnectionPoolConfig().keep_alive);
 }
 
@@ -697,4 +697,205 @@ TEST_F(CoreTest, KeepAliveTypeSafety) {
   
   runtime["keepAlive"] = false;
   EXPECT_FALSE(runtime["keepAlive"].get<bool>());
+}
+
+// ==================== isNull 测试 ====================
+// std::string 测试
+TEST_F(CoreTest, IsNullEmptyString) {
+  std::string emptyStr = "";
+  EXPECT_TRUE(Darabonba::isNull(emptyStr));
+}
+
+TEST_F(CoreTest, IsNullNonEmptyString) {
+  std::string str = "hello";
+  EXPECT_FALSE(Darabonba::isNull(str));
+}
+
+// 原始指针测试
+TEST_F(CoreTest, IsNullNullPointer) {
+  int* ptr = nullptr;
+  EXPECT_TRUE(Darabonba::isNull(ptr));
+}
+
+TEST_F(CoreTest, IsNullValidPointer) {
+  int value = 42;
+  int* ptr = &value;
+  EXPECT_FALSE(Darabonba::isNull(ptr));
+}
+
+// std::shared_ptr 测试
+TEST_F(CoreTest, IsNullEmptySharedPtr) {
+  std::shared_ptr<int> ptr;
+  EXPECT_TRUE(Darabonba::isNull(ptr));
+}
+
+TEST_F(CoreTest, IsNullValidSharedPtr) {
+  auto ptr = std::make_shared<int>(42);
+  EXPECT_FALSE(Darabonba::isNull(ptr));
+}
+
+TEST_F(CoreTest, IsNullResetSharedPtr) {
+  auto ptr = std::make_shared<int>(42);
+  ptr.reset();
+  EXPECT_TRUE(Darabonba::isNull(ptr));
+}
+
+// std::map 测试
+TEST_F(CoreTest, IsNullEmptyMap) {
+  std::map<std::string, std::string> emptyMap;
+  EXPECT_TRUE(Darabonba::isNull(emptyMap));
+}
+
+TEST_F(CoreTest, IsNullNonEmptyMap) {
+  std::map<std::string, std::string> map;
+  map["key"] = "value";
+  EXPECT_FALSE(Darabonba::isNull(map));
+}
+
+TEST_F(CoreTest, IsNullClearedMap) {
+  std::map<std::string, std::string> map;
+  map["key"] = "value";
+  map.clear();
+  EXPECT_TRUE(Darabonba::isNull(map));
+}
+
+// std::vector 测试
+TEST_F(CoreTest, IsNullEmptyVector) {
+  std::vector<int> emptyVec;
+  EXPECT_TRUE(Darabonba::isNull(emptyVec));
+}
+
+TEST_F(CoreTest, IsNullNonEmptyVector) {
+  std::vector<int> vec = {1, 2, 3};
+  EXPECT_FALSE(Darabonba::isNull(vec));
+}
+
+TEST_F(CoreTest, IsNullClearedVector) {
+  std::vector<int> vec = {1, 2, 3};
+  vec.clear();
+  EXPECT_TRUE(Darabonba::isNull(vec));
+}
+
+// 非指针类型默认行为测试
+TEST_F(CoreTest, IsNullIntValue) {
+  int value = 0;
+  EXPECT_FALSE(Darabonba::isNull(value));
+}
+
+TEST_F(CoreTest, IsNullDoubleValue) {
+  double value = 0.0;
+  EXPECT_FALSE(Darabonba::isNull(value));
+}
+
+// nullptr_t 测试
+TEST_F(CoreTest, IsNullNullptrT) {
+  EXPECT_TRUE(Darabonba::isNull(nullptr));
+}
+
+// 边界情况测试
+TEST_F(CoreTest, IsNullMapWithEmptyKey) {
+  std::map<std::string, std::string> map;
+  map[""] = "empty_key_value";
+  // 非空 map，应该返回 false
+  EXPECT_FALSE(Darabonba::isNull(map));
+}
+
+TEST_F(CoreTest, IsNullVectorWithZero) {
+  std::vector<int> vec = {0};
+  // 包含一个元素的 vector，应该返回 false
+  EXPECT_FALSE(Darabonba::isNull(vec));
+}
+
+// ==================== isNull(map, key) 测试 ====================
+// 语义：isNull(map, key) 返回 true 表示 key 不存在或值为 null
+TEST_F(CoreTest, IsNullMapKeyNotExists) {
+  std::map<std::string, std::string> map;
+  map["key"] = "value";
+  EXPECT_TRUE(Darabonba::isNull(map, std::string("missing")));  // key 不存在
+}
+
+TEST_F(CoreTest, IsNullMapKeyExistsWithValue) {
+  std::map<std::string, std::string> map;
+  map["key"] = "value";
+  EXPECT_FALSE(Darabonba::isNull(map, std::string("key")));  // key 存在，值非空
+}
+
+TEST_F(CoreTest, IsNullMapKeyExistsWithEmptyValue) {
+  std::map<std::string, std::string> map;
+  map["key"] = "";  // 空字符串
+  EXPECT_TRUE(Darabonba::isNull(map, std::string("key")));  // key 存在，但值为 null
+}
+
+TEST_F(CoreTest, IsNullMapKeyEmptyMap) {
+  std::map<std::string, std::string> map;
+  EXPECT_TRUE(Darabonba::isNull(map, std::string("any")));  // 空 map，任何 key 都是 null
+}
+
+TEST_F(CoreTest, IsNullMapKeyIntValue) {
+  std::map<std::string, int> map;
+  map["count"] = 0;
+  // int 类型 0 不是 null（isNull(int) 返回 false）
+  EXPECT_FALSE(Darabonba::isNull(map, std::string("count")));
+  EXPECT_TRUE(Darabonba::isNull(map, std::string("missing")));
+}
+
+// 验证 !isNull(map, key) 与 hasValue(map, key) 等价
+TEST_F(CoreTest, IsNullMapKeyEquivalenceToHasValue) {
+  std::map<std::string, std::string> map;
+  map["key"] = "value";
+  map["empty"] = "";
+  
+  // !isNull(map, key) == hasValue(map, key)
+  EXPECT_EQ(!Darabonba::isNull(map, std::string("key")), Darabonba::hasValue(map, std::string("key")));
+  EXPECT_EQ(!Darabonba::isNull(map, std::string("empty")), Darabonba::hasValue(map, std::string("empty")));
+  EXPECT_EQ(!Darabonba::isNull(map, std::string("missing")), Darabonba::hasValue(map, std::string("missing")));
+}
+
+// ==================== hasValue 测试 ====================
+TEST_F(CoreTest, HasValueKeyExists) {
+  std::map<std::string, std::string> map;
+  map["key"] = "value";
+  EXPECT_TRUE(Darabonba::hasValue(map, std::string("key")));
+}
+
+TEST_F(CoreTest, HasValueKeyNotExists) {
+  std::map<std::string, std::string> map;
+  map["key"] = "value";
+  EXPECT_FALSE(Darabonba::hasValue(map, std::string("missing")));
+}
+
+TEST_F(CoreTest, HasValueEmptyValue) {
+  std::map<std::string, std::string> map;
+  map["key"] = "";  // 空字符串
+  EXPECT_FALSE(Darabonba::hasValue(map, std::string("key")));  // 空值视为 null
+}
+
+TEST_F(CoreTest, HasValueEmptyMap) {
+  std::map<std::string, std::string> map;
+  EXPECT_FALSE(Darabonba::hasValue(map, std::string("any")));
+}
+
+// ==================== getOrDefault 测试 ====================
+TEST_F(CoreTest, GetOrDefaultKeyExists) {
+  std::map<std::string, std::string> map;
+  map["key"] = "value";
+  EXPECT_EQ(Darabonba::getOrDefault(map, std::string("key"), std::string("default")), "value");
+}
+
+TEST_F(CoreTest, GetOrDefaultKeyNotExists) {
+  std::map<std::string, std::string> map;
+  map["key"] = "value";
+  EXPECT_EQ(Darabonba::getOrDefault(map, std::string("missing"), std::string("default")), "default");
+}
+
+TEST_F(CoreTest, GetOrDefaultEmptyMap) {
+  std::map<std::string, std::string> map;
+  EXPECT_EQ(Darabonba::getOrDefault(map, std::string("key"), std::string("default")), "default");
+}
+
+TEST_F(CoreTest, GetOrDefaultIntValue) {
+  std::map<std::string, int> map;
+  map["count"] = 42;
+  EXPECT_EQ(Darabonba::getOrDefault(map, std::string("count"), 0), 42);
+  EXPECT_EQ(Darabonba::getOrDefault(map, std::string("missing"), -1), -1);
 }

--- a/tests/src/darabonba/test_Core.cpp
+++ b/tests/src/darabonba/test_Core.cpp
@@ -309,3 +309,392 @@ TEST_F(CoreTest, DoActionWithQueryParams) {
     std::cerr << "Network test skipped: " << e.what() << std::endl;
   }
 }
+
+// ==================== ConnectionPoolConfig 测试 ====================
+TEST_F(CoreTest, ConnectionPoolConfigDefaultValues) {
+  ConnectionPoolConfig config;
+  EXPECT_EQ(config.max_connections, 5UL);
+  EXPECT_EQ(config.max_host_connections, 2UL);
+  EXPECT_EQ(config.connection_idle_timeout, 300L);
+  EXPECT_FALSE(config.pipelining);
+  EXPECT_TRUE(config.keep_alive);
+}
+
+TEST_F(CoreTest, ConnectionPoolConfigWithKeepAlive) {
+  ConnectionPoolConfig config;
+  config.max_connections = 20;
+  config.keep_alive = false;
+  
+  EXPECT_EQ(config.max_connections, 20UL);
+  EXPECT_FALSE(config.keep_alive);
+}
+
+// ==================== MCurlHttpClient 连接池配置测试 ====================
+TEST_F(CoreTest, MCurlHttpClientSetConnectionPoolConfig) {
+  Http::MCurlHttpClient client;
+  
+  ConnectionPoolConfig config;
+  config.max_connections = 15;
+  config.keep_alive = false;
+  client.setConnectionPoolConfig(config);
+  
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 15UL);
+  EXPECT_FALSE(client.getConnectionPoolConfig().keep_alive);
+}
+
+TEST_F(CoreTest, MCurlHttpClientConfigAfterStart) {
+  Http::MCurlHttpClient client;
+  
+  ConnectionPoolConfig config;
+  config.max_connections = 25;
+  client.setConnectionPoolConfig(config);
+  
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 25UL);
+}
+
+// ==================== 配置传递测试 ====================
+TEST_F(CoreTest, MaxIdleConnsPropagationFromConfig) {
+  Core::ClearAllHttpClients();
+
+  try {
+    // Simulate what Client does: pass maxIdleConns from Config through runtime
+    Json runtime;
+    runtime["maxIdleConns"] = 20;
+    runtime["keepAlive"] = true;
+    runtime["timeout"] = 5000;
+
+    Http::Request request(std::string("https://config-test.aliyun.com"));
+    auto future = core.doAction(request, runtime);
+    future.wait_for(std::chrono::seconds(10));
+
+    EXPECT_EQ(Core::GetHttpClientCount(), 1UL);
+    Core::ClearAllHttpClients();
+
+  } catch (const std::exception &e) {
+    std::cerr << "Network test skipped: " << e.what() << std::endl;
+  }
+}
+
+TEST_F(CoreTest, ConfigUpdateOnExistingClient) {
+  Core::ClearAllHttpClients();
+
+  try {
+    Http::Request request(std::string("https://update-test.aliyun.com"));
+
+    {
+      Json runtime;
+      runtime["maxIdleConns"] = 10;
+      auto future = core.doAction(request, runtime);
+      future.wait_for(std::chrono::seconds(10));
+    }
+
+    {
+      Json runtime;
+      runtime["maxIdleConns"] = 30;
+      auto future = core.doAction(request, runtime);
+      future.wait_for(std::chrono::seconds(10));
+    }
+
+    EXPECT_EQ(Core::GetHttpClientCount(), 1UL);
+    Core::ClearAllHttpClients();
+
+  } catch (const std::exception &e) {
+    std::cerr << "Network test skipped: " << e.what() << std::endl;
+  }
+}
+
+// ==================== ConnectionPoolConfig 边界测试 ====================
+TEST_F(CoreTest, ConnectionPoolConfigZeroConnections) {
+  ConnectionPoolConfig config;
+  config.max_connections = 0;
+  EXPECT_EQ(config.max_connections, 0UL);
+}
+
+TEST_F(CoreTest, ConnectionPoolConfigLargeConnections) {
+  ConnectionPoolConfig config;
+  config.max_connections = 10000;
+  EXPECT_EQ(config.max_connections, 10000UL);
+}
+
+TEST_F(CoreTest, ConnectionPoolConfigCompareOperator) {
+  ConnectionPoolConfig config1;
+  config1.host = "api.test.com";
+  config1.max_connections = 10;
+  
+  ConnectionPoolConfig config2;
+  config2.host = "api.test.com";
+  config2.max_connections = 20;
+  
+  EXPECT_TRUE(config1 < config2);
+  EXPECT_FALSE(config2 < config1);
+}
+
+TEST_F(CoreTest, ConnectionPoolConfigAllFields) {
+  ConnectionPoolConfig config;
+  config.host = "api.example.com";
+  config.max_connections = 100;
+  config.max_host_connections = 10;
+  config.connection_idle_timeout = 600L;
+  config.pipelining = true;
+  config.keep_alive = false;
+  
+  EXPECT_EQ(config.host, "api.example.com");
+  EXPECT_EQ(config.max_connections, 100UL);
+  EXPECT_EQ(config.max_host_connections, 10UL);
+  EXPECT_EQ(config.connection_idle_timeout, 600L);
+  EXPECT_TRUE(config.pipelining);
+  EXPECT_FALSE(config.keep_alive);
+}
+
+TEST_F(CoreTest, ConnectionPoolConfigCopy) {
+  ConnectionPoolConfig config1;
+  config1.host = "original.com";
+  config1.max_connections = 30;
+  config1.keep_alive = false;
+  
+  ConnectionPoolConfig config2 = config1;
+  
+  EXPECT_EQ(config2.host, "original.com");
+  EXPECT_EQ(config2.max_connections, 30UL);
+  EXPECT_FALSE(config2.keep_alive);
+  
+  config1.host = "modified.com";
+  EXPECT_EQ(config2.host, "original.com");
+}
+
+// ==================== MCurlHttpClient 详细测试 ====================
+TEST_F(CoreTest, MCurlHttpClientDefaultConnectionPoolConfig) {
+  Http::MCurlHttpClient client;
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 5UL);
+  EXPECT_TRUE(client.getConnectionPoolConfig().keep_alive);
+}
+
+TEST_F(CoreTest, MCurlHttpClientConfigOverride) {
+  Http::MCurlHttpClient client;
+  
+  ConnectionPoolConfig config1;
+  config1.max_connections = 10;
+  config1.keep_alive = true;
+  client.setConnectionPoolConfig(config1);
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 10UL);
+  EXPECT_TRUE(client.getConnectionPoolConfig().keep_alive);
+  
+  ConnectionPoolConfig config2;
+  config2.max_connections = 20;
+  config2.keep_alive = false;
+  client.setConnectionPoolConfig(config2);
+  EXPECT_EQ(client.getConnectionPoolConfig().max_connections, 20UL);
+  EXPECT_FALSE(client.getConnectionPoolConfig().keep_alive);
+}
+
+TEST_F(CoreTest, MCurlHttpClientStartStop) {
+  Http::MCurlHttpClient client;
+  
+  ConnectionPoolConfig config;
+  config.max_connections = 15;
+  client.setConnectionPoolConfig(config);
+  
+  EXPECT_TRUE(client.start());
+  EXPECT_FALSE(client.start());  // Already running
+  EXPECT_TRUE(client.stop());
+  EXPECT_FALSE(client.stop());   // Already stopped
+}
+
+// ==================== Keep-Alive 配置测试 ====================
+TEST_F(CoreTest, KeepAliveDefaultTrue) {
+  ConnectionPoolConfig config;
+  EXPECT_TRUE(config.keep_alive);
+}
+
+TEST_F(CoreTest, KeepAliveSetFalse) {
+  ConnectionPoolConfig config;
+  config.keep_alive = false;
+  EXPECT_FALSE(config.keep_alive);
+}
+
+TEST_F(CoreTest, KeepAliveDisabledConfig) {
+  ConnectionPoolConfig config;
+  config.keep_alive = false;
+  
+  Http::MCurlHttpClient client;
+  client.setConnectionPoolConfig(config);
+  
+  EXPECT_FALSE(client.getConnectionPoolConfig().keep_alive);
+}
+
+TEST_F(CoreTest, KeepAliveEnabledConfig) {
+  ConnectionPoolConfig config;
+  config.keep_alive = true;
+  
+  Http::MCurlHttpClient client;
+  client.setConnectionPoolConfig(config);
+  
+  EXPECT_TRUE(client.getConnectionPoolConfig().keep_alive);
+}
+
+// ==================== 默认超时测试 ====================
+TEST_F(CoreTest, DefaultReadTimeout) {
+  Json runtime;
+  // 不设置 readTimeout，应该使用默认值
+  
+  Http::Request request(std::string("https://timeout-test.aliyun.com"));
+  // 验证 runtime 可以正确处理
+  EXPECT_NO_THROW({
+    auto future = core.doAction(request, runtime);
+    future.wait_for(std::chrono::seconds(10));
+  });
+  
+  Core::ClearAllHttpClients();
+}
+
+TEST_F(CoreTest, CustomReadTimeout) {
+  Json runtime;
+  runtime["readTimeout"] = 5000;
+  
+  Http::Request request(std::string("https://custom-timeout.aliyun.com"));
+  EXPECT_NO_THROW({
+    auto future = core.doAction(request, runtime);
+    future.wait_for(std::chrono::seconds(10));
+  });
+  
+  Core::ClearAllHttpClients();
+}
+
+// ==================== 多 Host 客户端管理测试 ====================
+TEST_F(CoreTest, MultipleHostsMultipleClients) {
+  Core::ClearAllHttpClients();
+  
+  try {
+    Json runtime;
+    runtime["maxIdleConns"] = 10;
+    
+    Http::Request request1(std::string("https://host1.aliyun.com"));
+    auto f1 = core.doAction(request1, runtime);
+    f1.wait_for(std::chrono::seconds(10));
+    
+    Http::Request request2(std::string("https://host2.aliyun.com"));
+    auto f2 = core.doAction(request2, runtime);
+    f2.wait_for(std::chrono::seconds(10));
+    
+    EXPECT_EQ(Core::GetHttpClientCount(), 2UL);
+    
+    Core::ClearAllHttpClients();
+    
+  } catch (const std::exception &e) {
+    std::cerr << "Network test skipped: " << e.what() << std::endl;
+  }
+}
+
+TEST_F(CoreTest, SameHostReusesClient) {
+  Core::ClearAllHttpClients();
+  
+  try {
+    Json runtime;
+    runtime["maxIdleConns"] = 10;
+    
+    for (int i = 0; i < 3; i++) {
+      Http::Request request(std::string("https://same-host.aliyun.com"));
+      auto future = core.doAction(request, runtime);
+      future.wait_for(std::chrono::seconds(10));
+    }
+    
+    EXPECT_EQ(Core::GetHttpClientCount(), 1UL);
+    
+    Core::ClearAllHttpClients();
+    
+  } catch (const std::exception &e) {
+    std::cerr << "Network test skipped: " << e.what() << std::endl;
+  }
+}
+
+// ==================== ClearHttpClient 测试 ====================
+TEST_F(CoreTest, ClearSpecificHttpClient) {
+  Core::ClearAllHttpClients();
+  
+  try {
+    Json runtime;
+    
+    Http::Request request1(std::string("https://clear-test1.aliyun.com"));
+    auto f1 = core.doAction(request1, runtime);
+    f1.wait_for(std::chrono::seconds(10));
+    
+    Http::Request request2(std::string("https://clear-test2.aliyun.com"));
+    auto f2 = core.doAction(request2, runtime);
+    f2.wait_for(std::chrono::seconds(10));
+    
+    EXPECT_EQ(Core::GetHttpClientCount(), 2UL);
+    
+    ConnectionPoolConfig config;
+    config.host = "clear-test1.aliyun.com";
+    Core::ClearHttpClient(config);
+    
+    EXPECT_EQ(Core::GetHttpClientCount(), 1UL);
+    
+    Core::ClearAllHttpClients();
+    
+  } catch (const std::exception &e) {
+    std::cerr << "Network test skipped: " << e.what() << std::endl;
+  }
+}
+
+// ==================== 内存管理测试 ====================
+TEST_F(CoreTest, ClientCleanupOnDestruction) {
+  {
+    Http::MCurlHttpClient* client = new Http::MCurlHttpClient();
+    client->start();
+    
+    ConnectionPoolConfig config;
+    config.max_connections = 10;
+    client->setConnectionPoolConfig(config);
+    
+    delete client;
+  }
+  
+  EXPECT_TRUE(true);
+}
+
+TEST_F(CoreTest, MultipleClearAllHttpClients) {
+  Core::ClearAllHttpClients();
+  Core::ClearAllHttpClients();
+  Core::ClearAllHttpClients();
+  
+  EXPECT_EQ(Core::GetHttpClientCount(), 0UL);
+}
+
+// ==================== 空配置测试 ====================
+TEST_F(CoreTest, EmptyRuntimeOptions) {
+  Core::ClearAllHttpClients();
+  
+  try {
+    Http::Request request(std::string("https://empty-runtime.aliyun.com"));
+    Json runtime;
+    
+    auto future = core.doAction(request, runtime);
+    future.wait_for(std::chrono::seconds(10));
+    
+    EXPECT_EQ(Core::GetHttpClientCount(), 1UL);
+    
+    Core::ClearAllHttpClients();
+    
+  } catch (const std::exception &e) {
+    std::cerr << "Network test skipped: " << e.what() << std::endl;
+  }
+}
+
+// ==================== 配置类型安全测试 ====================
+TEST_F(CoreTest, MaxIdleConnsTypeSafety) {
+  Json runtime;
+  runtime["maxIdleConns"] = 50;
+  
+  EXPECT_EQ(runtime["maxIdleConns"].get<int64_t>(), 50);
+}
+
+TEST_F(CoreTest, KeepAliveTypeSafety) {
+  Json runtime;
+  runtime["keepAlive"] = true;
+  
+  EXPECT_TRUE(runtime["keepAlive"].get<bool>());
+  
+  runtime["keepAlive"] = false;
+  EXPECT_FALSE(runtime["keepAlive"].get<bool>());
+}

--- a/tests/src/darabonba/test_Core.cpp
+++ b/tests/src/darabonba/test_Core.cpp
@@ -34,8 +34,8 @@ TEST_F(CoreTest, SleepShouldWorkCorrectly) {
   EXPECT_LE(duration, 300);
 }
 
-// ==================== allowRetry 测试 ====================
-TEST_F(CoreTest, AllowRetryWithFirstAttempt) {
+// ==================== shouldRetry 测试 ====================
+TEST_F(CoreTest, ShouldRetryWithFirstAttempt) {
   Policy::RetryOptions options;
   options.setRetryable(true);
 
@@ -48,10 +48,10 @@ TEST_F(CoreTest, AllowRetryWithFirstAttempt) {
   ctx.setRetriesAttempted(0); // 第一次尝试
 
   // 第一次尝试应该允许重试
-  EXPECT_TRUE(Darabonba::allowRetry(options, ctx));
+  EXPECT_TRUE(Darabonba::shouldRetry(options, ctx));
 }
 
-TEST_F(CoreTest, AllowRetryWithMaxAttemptsReached) {
+TEST_F(CoreTest, ShouldRetryWithMaxAttemptsReached) {
   Policy::RetryOptions options;
   options.setRetryable(true);
 
@@ -67,10 +67,10 @@ TEST_F(CoreTest, AllowRetryWithMaxAttemptsReached) {
   ctx.setException(ex);
 
   // 已达到最大重试次数，不应该允许重试
-  EXPECT_FALSE(Darabonba::allowRetry(options, ctx));
+  EXPECT_FALSE(Darabonba::shouldRetry(options, ctx));
 }
 
-TEST_F(CoreTest, AllowRetryWhenNotRetryable) {
+TEST_F(CoreTest, ShouldRetryWhenNotRetryable) {
   Policy::RetryOptions options;
   options.setRetryable(false); // 不可重试
 
@@ -78,10 +78,10 @@ TEST_F(CoreTest, AllowRetryWhenNotRetryable) {
   ctx.setRetriesAttempted(1);
 
   // 不可重试选项应该返回 false
-  EXPECT_FALSE(Darabonba::allowRetry(options, ctx));
+  EXPECT_FALSE(Darabonba::shouldRetry(options, ctx));
 }
 
-TEST_F(CoreTest, AllowRetryWithMatchingException) {
+TEST_F(CoreTest, ShouldRetryWithMatchingException) {
   Policy::RetryOptions options;
   options.setRetryable(true);
 
@@ -97,7 +97,7 @@ TEST_F(CoreTest, AllowRetryWithMatchingException) {
   ctx.setException(ex);
 
   // 匹配的异常类型应该允许重试
-  EXPECT_TRUE(Darabonba::allowRetry(options, ctx));
+  EXPECT_TRUE(Darabonba::shouldRetry(options, ctx));
 }
 
 // ==================== getBackoffTime 测试 ====================

--- a/tests/src/darabonba/test_Core.cpp
+++ b/tests/src/darabonba/test_Core.cpp
@@ -899,3 +899,86 @@ TEST_F(CoreTest, GetOrDefaultIntValue) {
   EXPECT_EQ(Darabonba::getOrDefault(map, std::string("count"), 0), 42);
   EXPECT_EQ(Darabonba::getOrDefault(map, std::string("missing"), -1), -1);
 }
+
+// ==================== int64_t 超时值测试 ====================
+// 这些测试证明了使用 int64_t 而非 long 的必要性
+// 在 Windows 平台上，long 是 32 位的，无法正确处理大于 INT32_MAX 的超时值
+
+// 测试 ConnectionPoolConfig 的 connection_idle_timeout 支持 int64_t
+TEST_F(CoreTest, ConnectionPoolConfigLargeIdleTimeout) {
+  ConnectionPoolConfig config;
+  // 设置一个大于 INT32_MAX 的值（秒）
+  // INT32_MAX = 2147483647，我们用一个更大的值
+  config.connection_idle_timeout = 3000000000LL;  // 大于 INT32_MAX
+  EXPECT_EQ(config.connection_idle_timeout, 3000000000LL);
+  // 验证这个值远超 INT32_MAX，在 32-bit long 系统上会溢出
+  EXPECT_GT(config.connection_idle_timeout, 2147483647LL);
+}
+
+// 测试 RequestConfig 的 connect_timeout_ms 支持 int64_t
+TEST_F(CoreTest, RequestConfigLargeConnectTimeout) {
+  RequestConfig config;
+  // 设置一个大超时值（毫秒）
+  config.connect_timeout_ms = 2147483648LL;  // INT32_MAX + 1
+  EXPECT_EQ(config.connect_timeout_ms, 2147483648LL);
+  // 验证这个值在 Windows long (32-bit) 上会溢出
+  EXPECT_GT(config.connect_timeout_ms, static_cast<long>(2147483647L));
+}
+
+// 测试 RequestConfig 的 read_timeout_ms 支持 int64_t
+TEST_F(CoreTest, RequestConfigLargeReadTimeout) {
+  RequestConfig config;
+  // 设置一个大超时值（毫秒）- 必须大于 INT32_MAX
+  config.read_timeout_ms = 3000000000LL;  // 大于 INT32_MAX
+  EXPECT_EQ(config.read_timeout_ms, 3000000000LL);
+  // 验证这个值在 Windows long (32-bit) 上会溢出
+  EXPECT_GT(config.read_timeout_ms, 2147483647LL);
+}
+
+// 测试 RequestConfig 所有字段都能正确存储 int64_t 值
+TEST_F(CoreTest, RequestConfigAllTimeoutFields) {
+  RequestConfig config;
+  config.connect_timeout_ms = 300000LL;   // 5 分钟
+  config.read_timeout_ms = 3600000LL;     // 1 小时
+
+  EXPECT_EQ(config.connect_timeout_ms, 300000LL);
+  EXPECT_EQ(config.read_timeout_ms, 3600000LL);
+}
+
+// 测试超时值类型正确性 - 验证是 int64_t
+TEST_F(CoreTest, TimeoutTypeIsInt64) {
+  // 编译时验证类型
+  static_assert(std::is_same<decltype(ConnectionPoolConfig::connection_idle_timeout), int64_t>::value,
+                "connection_idle_timeout should be int64_t");
+  static_assert(std::is_same<decltype(RequestConfig::connect_timeout_ms), int64_t>::value,
+                "connect_timeout_ms should be int64_t");
+  static_assert(std::is_same<decltype(RequestConfig::read_timeout_ms), int64_t>::value,
+                "read_timeout_ms should be int64_t");
+}
+
+// 测试负值超时（边界情况）
+TEST_F(CoreTest, RequestConfigNegativeTimeout) {
+  RequestConfig config;
+  // 虽然 API 不应该接受负值，但类型应该能存储
+  config.connect_timeout_ms = -1;
+  config.read_timeout_ms = -1;
+  EXPECT_EQ(config.connect_timeout_ms, -1LL);
+  EXPECT_EQ(config.read_timeout_ms, -1LL);
+}
+
+// 测试零超时值
+TEST_F(CoreTest, RequestConfigZeroTimeout) {
+  RequestConfig config;
+  config.connect_timeout_ms = 0;
+  config.read_timeout_ms = 0;
+  EXPECT_EQ(config.connect_timeout_ms, 0LL);
+  EXPECT_EQ(config.read_timeout_ms, 0LL);
+}
+
+// 测试默认超时值
+TEST_F(CoreTest, RequestConfigDefaultTimeoutValues) {
+  RequestConfig config;
+  EXPECT_EQ(config.connect_timeout_ms, 5000LL);
+  EXPECT_EQ(config.read_timeout_ms, 0LL);
+  EXPECT_FALSE(config.ignore_ssl);
+}

--- a/tests/src/darabonba/test_Logger.cpp
+++ b/tests/src/darabonba/test_Logger.cpp
@@ -264,7 +264,7 @@ TEST_F(LoggerTest, ConcurrentLogging) {
   std::vector<std::thread> threads;
 
   for (int i = 0; i < numThreads; ++i) {
-    threads.emplace_back([i]() {
+    threads.emplace_back([i, messagesPerThread]() {
       for (int j = 0; j < messagesPerThread; ++j) {
         Logger::debug("Thread " + std::to_string(i) + " message " + std::to_string(j));
         Logger::info("Thread " + std::to_string(i) + " message " + std::to_string(j));
@@ -395,13 +395,13 @@ TEST_F(LoggerTest, SilenceAllLogsScenario) {
 TEST_F(LoggerTest, SuppressedMessagesHaveMinimalOverhead) {
   Logger::setLevel(LogLevel::OFF);
 
-  auto start = std::chrono::high_resolution_clock::now();
+  auto start = std::chrono::steady_clock::now();
 
   for (int i = 0; i < 10000; ++i) {
     Logger::debug("This message is suppressed");
   }
 
-  auto end = std::chrono::high_resolution_clock::now();
+  auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
   // 10000 suppressed messages should take very little time (< 100ms)
@@ -409,14 +409,14 @@ TEST_F(LoggerTest, SuppressedMessagesHaveMinimalOverhead) {
 }
 
 TEST_F(LoggerTest, LevelCheckIsFast) {
-  auto start = std::chrono::high_resolution_clock::now();
+  auto start = std::chrono::steady_clock::now();
 
   for (int i = 0; i < 100000; ++i) {
     LogLevel level = Logger::getLevel();
     (void)level;
   }
 
-  auto end = std::chrono::high_resolution_clock::now();
+  auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
   // 100000 level checks should be very fast (< 50ms)

--- a/tests/src/darabonba/test_Logger.cpp
+++ b/tests/src/darabonba/test_Logger.cpp
@@ -260,12 +260,11 @@ TEST_F(LoggerTest, ConcurrentSetLevel) {
 TEST_F(LoggerTest, ConcurrentLogging) {
   Logger::setLevel(LogLevel::DEBUG);
   const int numThreads = 10;
-  int messagesPerThread = 100;
   std::vector<std::thread> threads;
 
   for (int i = 0; i < numThreads; ++i) {
-    threads.emplace_back([i, messagesPerThread]() {
-      for (int j = 0; j < messagesPerThread; ++j) {
+    threads.emplace_back([i]() {
+      for (int j = 0; j < 100; ++j) {
         Logger::debug("Thread " + std::to_string(i) + " message " + std::to_string(j));
         Logger::info("Thread " + std::to_string(i) + " message " + std::to_string(j));
         Logger::warning("Thread " + std::to_string(i) + " message " + std::to_string(j));

--- a/tests/src/darabonba/test_Logger.cpp
+++ b/tests/src/darabonba/test_Logger.cpp
@@ -1,0 +1,424 @@
+#include <darabonba/Logger.hpp>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+using namespace Darabonba;
+
+class LoggerTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // Save original log level
+    originalLevel_ = Logger::getLevel();
+    // Reset to default before each test
+    Logger::setLevel(LogLevel::WARNING);
+  }
+
+  void TearDown() override {
+    // Restore original log level
+    Logger::setLevel(originalLevel_);
+  }
+
+private:
+  LogLevel originalLevel_;
+};
+
+// ==================== LogLevel Enumeration Tests ====================
+
+TEST_F(LoggerTest, LogLevelValues) {
+  // Verify log level ordering (lower = more verbose)
+  EXPECT_LT(static_cast<int>(LogLevel::DEBUG), static_cast<int>(LogLevel::INFO));
+  EXPECT_LT(static_cast<int>(LogLevel::INFO), static_cast<int>(LogLevel::WARNING));
+  EXPECT_LT(static_cast<int>(LogLevel::WARNING), static_cast<int>(LogLevel::ERROR));
+  EXPECT_LT(static_cast<int>(LogLevel::ERROR), static_cast<int>(LogLevel::OFF));
+}
+
+TEST_F(LoggerTest, LogLevelDebugValue) {
+  EXPECT_EQ(0, static_cast<int>(LogLevel::DEBUG));
+}
+
+TEST_F(LoggerTest, LogLevelInfoValue) {
+  EXPECT_EQ(1, static_cast<int>(LogLevel::INFO));
+}
+
+TEST_F(LoggerTest, LogLevelWarningValue) {
+  EXPECT_EQ(2, static_cast<int>(LogLevel::WARNING));
+}
+
+TEST_F(LoggerTest, LogLevelErrorValue) {
+  EXPECT_EQ(3, static_cast<int>(LogLevel::ERROR));
+}
+
+TEST_F(LoggerTest, LogLevelOffValue) {
+  EXPECT_EQ(4, static_cast<int>(LogLevel::OFF));
+}
+
+// ==================== Default Log Level Tests ====================
+
+TEST_F(LoggerTest, DefaultLogLevelIsWarning) {
+  EXPECT_EQ(LogLevel::WARNING, Logger::getLevel());
+}
+
+TEST_F(LoggerTest, SetAndGetLogLevel) {
+  Logger::setLevel(LogLevel::DEBUG);
+  EXPECT_EQ(LogLevel::DEBUG, Logger::getLevel());
+
+  Logger::setLevel(LogLevel::INFO);
+  EXPECT_EQ(LogLevel::INFO, Logger::getLevel());
+
+  Logger::setLevel(LogLevel::ERROR);
+  EXPECT_EQ(LogLevel::ERROR, Logger::getLevel());
+
+  Logger::setLevel(LogLevel::OFF);
+  EXPECT_EQ(LogLevel::OFF, Logger::getLevel());
+}
+
+// ==================== Log Level Filtering Tests ====================
+
+TEST_F(LoggerTest, DebugLevelShowsAllMessages) {
+  Logger::setLevel(LogLevel::DEBUG);
+
+  // All levels should be visible when set to DEBUG
+  // These should not throw or crash
+  EXPECT_NO_THROW(Logger::debug("debug message"));
+  EXPECT_NO_THROW(Logger::info("info message"));
+  EXPECT_NO_THROW(Logger::warning("warning message"));
+  EXPECT_NO_THROW(Logger::error("error message"));
+}
+
+TEST_F(LoggerTest, InfoLevelHidesDebug) {
+  Logger::setLevel(LogLevel::INFO);
+
+  // DEBUG should be suppressed, others visible
+  EXPECT_NO_THROW(Logger::debug("should be suppressed"));
+  EXPECT_NO_THROW(Logger::info("info message"));
+  EXPECT_NO_THROW(Logger::warning("warning message"));
+  EXPECT_NO_THROW(Logger::error("error message"));
+}
+
+TEST_F(LoggerTest, WarningLevelHidesDebugAndInfo) {
+  Logger::setLevel(LogLevel::WARNING);
+
+  // DEBUG and INFO should be suppressed
+  EXPECT_NO_THROW(Logger::debug("should be suppressed"));
+  EXPECT_NO_THROW(Logger::info("should be suppressed"));
+  EXPECT_NO_THROW(Logger::warning("warning message"));
+  EXPECT_NO_THROW(Logger::error("error message"));
+}
+
+TEST_F(LoggerTest, ErrorLevelShowsOnlyError) {
+  Logger::setLevel(LogLevel::ERROR);
+
+  // Only ERROR should be visible
+  EXPECT_NO_THROW(Logger::debug("should be suppressed"));
+  EXPECT_NO_THROW(Logger::info("should be suppressed"));
+  EXPECT_NO_THROW(Logger::warning("should be suppressed"));
+  EXPECT_NO_THROW(Logger::error("error message"));
+}
+
+TEST_F(LoggerTest, OffLevelHidesAll) {
+  Logger::setLevel(LogLevel::OFF);
+
+  // All messages should be suppressed
+  EXPECT_NO_THROW(Logger::debug("should be suppressed"));
+  EXPECT_NO_THROW(Logger::info("should be suppressed"));
+  EXPECT_NO_THROW(Logger::warning("should be suppressed"));
+  EXPECT_NO_THROW(Logger::error("should be suppressed"));
+}
+
+// ==================== Log Method Tests ====================
+
+TEST_F(LoggerTest, LogMethodCallsInfo) {
+  Logger::setLevel(LogLevel::INFO);
+
+  // log() should delegate to info()
+  EXPECT_NO_THROW(Logger::log("log message"));
+}
+
+TEST_F(LoggerTest, DebugMethodAtDebugLevel) {
+  Logger::setLevel(LogLevel::DEBUG);
+  EXPECT_NO_THROW(Logger::debug("debug test"));
+}
+
+TEST_F(LoggerTest, InfoMethodAtInfoLevel) {
+  Logger::setLevel(LogLevel::INFO);
+  EXPECT_NO_THROW(Logger::info("info test"));
+}
+
+TEST_F(LoggerTest, WarningMethodAtWarningLevel) {
+  Logger::setLevel(LogLevel::WARNING);
+  EXPECT_NO_THROW(Logger::warning("warning test"));
+}
+
+TEST_F(LoggerTest, ErrorMethodAtErrorLevel) {
+  Logger::setLevel(LogLevel::ERROR);
+  EXPECT_NO_THROW(Logger::error("error test"));
+}
+
+// ==================== Boundary Tests ====================
+
+TEST_F(LoggerTest, SetLevelMultipleTimes) {
+  Logger::setLevel(LogLevel::DEBUG);
+  EXPECT_EQ(LogLevel::DEBUG, Logger::getLevel());
+
+  Logger::setLevel(LogLevel::WARNING);
+  EXPECT_EQ(LogLevel::WARNING, Logger::getLevel());
+
+  Logger::setLevel(LogLevel::DEBUG);
+  EXPECT_EQ(LogLevel::DEBUG, Logger::getLevel());
+}
+
+TEST_F(LoggerTest, SetSameLevelMultipleTimes) {
+  Logger::setLevel(LogLevel::INFO);
+  Logger::setLevel(LogLevel::INFO);
+  Logger::setLevel(LogLevel::INFO);
+
+  EXPECT_EQ(LogLevel::INFO, Logger::getLevel());
+}
+
+// ==================== Edge Cases ====================
+
+TEST_F(LoggerTest, EmptyMessage) {
+  Logger::setLevel(LogLevel::DEBUG);
+
+  // Empty strings should not cause issues
+  EXPECT_NO_THROW(Logger::debug(""));
+  EXPECT_NO_THROW(Logger::info(""));
+  EXPECT_NO_THROW(Logger::warning(""));
+  EXPECT_NO_THROW(Logger::error(""));
+}
+
+TEST_F(LoggerTest, LongMessage) {
+  Logger::setLevel(LogLevel::DEBUG);
+
+  // Long strings should work
+  std::string longMessage(10000, 'a');
+  EXPECT_NO_THROW(Logger::debug(longMessage));
+  EXPECT_NO_THROW(Logger::info(longMessage));
+  EXPECT_NO_THROW(Logger::warning(longMessage));
+  EXPECT_NO_THROW(Logger::error(longMessage));
+}
+
+TEST_F(LoggerTest, MessageWithNewlines) {
+  Logger::setLevel(LogLevel::DEBUG);
+
+  // Messages with newlines
+  EXPECT_NO_THROW(Logger::debug("line1\nline2\nline3"));
+  EXPECT_NO_THROW(Logger::info("line1\nline2"));
+  EXPECT_NO_THROW(Logger::warning("line1\r\nline2"));
+  EXPECT_NO_THROW(Logger::error("line1\r\nline2\r\n"));
+}
+
+TEST_F(LoggerTest, MessageWithSpecialCharacters) {
+  Logger::setLevel(LogLevel::DEBUG);
+
+  // Special characters
+  EXPECT_NO_THROW(Logger::debug("Special: \t\b\n\r"));
+  EXPECT_NO_THROW(Logger::info("Quotes: \"'`"));
+  EXPECT_NO_THROW(Logger::warning("Symbols: !@#$%^&*()"));
+  EXPECT_NO_THROW(Logger::error("Unicode: 中文 日本語 한글"));
+}
+
+TEST_F(LoggerTest, MessageWithFormatLikeStrings) {
+  Logger::setLevel(LogLevel::DEBUG);
+
+  // Format-like strings (should not be interpreted)
+  EXPECT_NO_THROW(Logger::debug("%s %d %f"));
+  EXPECT_NO_THROW(Logger::info("{} {0} {1}"));
+  EXPECT_NO_THROW(Logger::warning("%1$s %2$d"));
+  EXPECT_NO_THROW(Logger::error("${var} #{var}"));
+}
+
+// ==================== Thread Safety Tests ====================
+
+TEST_F(LoggerTest, ConcurrentSetLevel) {
+  const int numThreads = 10;
+  std::vector<std::thread> threads;
+
+  for (int i = 0; i < numThreads; ++i) {
+    threads.emplace_back([i]() {
+      LogLevel level = static_cast<LogLevel>(i % 5);
+      Logger::setLevel(level);
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // Should not crash, level should be one of the valid values
+  LogLevel finalLevel = Logger::getLevel();
+  EXPECT_TRUE(finalLevel == LogLevel::DEBUG ||
+              finalLevel == LogLevel::INFO ||
+              finalLevel == LogLevel::WARNING ||
+              finalLevel == LogLevel::ERROR ||
+              finalLevel == LogLevel::OFF);
+}
+
+TEST_F(LoggerTest, ConcurrentLogging) {
+  Logger::setLevel(LogLevel::DEBUG);
+  const int numThreads = 10;
+  const int messagesPerThread = 100;
+  std::vector<std::thread> threads;
+
+  for (int i = 0; i < numThreads; ++i) {
+    threads.emplace_back([i]() {
+      for (int j = 0; j < messagesPerThread; ++j) {
+        Logger::debug("Thread " + std::to_string(i) + " message " + std::to_string(j));
+        Logger::info("Thread " + std::to_string(i) + " message " + std::to_string(j));
+        Logger::warning("Thread " + std::to_string(i) + " message " + std::to_string(j));
+        Logger::error("Thread " + std::to_string(i) + " message " + std::to_string(j));
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // Should complete without crashes
+  SUCCEED();
+}
+
+TEST_F(LoggerTest, ConcurrentSetLevelAndLogging) {
+  const int numThreads = 20;
+  std::vector<std::thread> threads;
+  std::atomic<bool> stop(false);
+
+  // Thread that changes log levels
+  threads.emplace_back([&stop]() {
+    for (int i = 0; i < 100 && !stop; ++i) {
+      Logger::setLevel(static_cast<LogLevel>(i % 5));
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  });
+
+  // Threads that log messages
+  for (int i = 0; i < numThreads - 1; ++i) {
+    threads.emplace_back([&stop, i]() {
+      for (int j = 0; j < 50 && !stop; ++j) {
+        Logger::debug("Thread " + std::to_string(i));
+        Logger::info("Thread " + std::to_string(i));
+        Logger::warning("Thread " + std::to_string(i));
+        Logger::error("Thread " + std::to_string(i));
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // Should complete without crashes
+  SUCCEED();
+}
+
+// ==================== Output Stream Tests ====================
+
+// Note: These tests verify that debug/info go to stdout and warning/error go to stderr
+// We can't easily capture the output in a portable way, but we verify no crashes
+
+TEST_F(LoggerTest, DebugOutputsToStdout) {
+  Logger::setLevel(LogLevel::DEBUG);
+  EXPECT_NO_THROW(Logger::debug("stdout test"));
+}
+
+TEST_F(LoggerTest, InfoOutputsToStdout) {
+  Logger::setLevel(LogLevel::INFO);
+  EXPECT_NO_THROW(Logger::info("stdout test"));
+}
+
+TEST_F(LoggerTest, WarningOutputsToStderr) {
+  Logger::setLevel(LogLevel::WARNING);
+  EXPECT_NO_THROW(Logger::warning("stderr test"));
+}
+
+TEST_F(LoggerTest, ErrorOutputsToStderr) {
+  Logger::setLevel(LogLevel::ERROR);
+  EXPECT_NO_THROW(Logger::error("stderr test"));
+}
+
+// ==================== Backward Compatibility Tests ====================
+
+TEST_F(LoggerTest, GlobalTypedefWorks) {
+  // Verify backward compatibility typedefs
+  DarabonbaLogger logger;
+  (void)logger;  // Suppress unused variable warning
+
+  DarabonbaLogLevel level = DarabonbaLogLevel::DEBUG;
+  EXPECT_EQ(static_cast<int>(level), 0);
+}
+
+// ==================== Typical Usage Scenarios ====================
+
+TEST_F(LoggerTest, TypicalUsageScenario) {
+  // Production-like scenario
+  Logger::setLevel(LogLevel::WARNING);
+
+  // Debug and info suppressed
+  Logger::debug("This won't appear in production");
+  Logger::info("This won't appear either");
+
+  // Only warnings and errors shown
+  Logger::warning("Configuration file not found, using defaults");
+  Logger::error("Failed to connect to server");
+}
+
+TEST_F(LoggerTest, DevelopmentUsageScenario) {
+  // Development scenario
+  Logger::setLevel(LogLevel::DEBUG);
+
+  // All messages shown
+  Logger::debug("Entering function processData()");
+  Logger::info("Processing 100 records");
+  Logger::warning("Record 50 has missing field");
+  Logger::error("Failed to process record 75");
+}
+
+TEST_F(LoggerTest, SilenceAllLogsScenario) {
+  // Completely silence logging
+  Logger::setLevel(LogLevel::OFF);
+
+  Logger::debug("Suppressed");
+  Logger::info("Suppressed");
+  Logger::warning("Suppressed");
+  Logger::error("Suppressed");
+
+  // Verify level is OFF
+  EXPECT_EQ(LogLevel::OFF, Logger::getLevel());
+}
+
+// ==================== Performance Tests ====================
+
+TEST_F(LoggerTest, SuppressedMessagesHaveMinimalOverhead) {
+  Logger::setLevel(LogLevel::OFF);
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  for (int i = 0; i < 10000; ++i) {
+    Logger::debug("This message is suppressed");
+  }
+
+  auto end = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+  // 10000 suppressed messages should take very little time (< 100ms)
+  EXPECT_LT(duration.count(), 100);
+}
+
+TEST_F(LoggerTest, LevelCheckIsFast) {
+  auto start = std::chrono::high_resolution_clock::now();
+
+  for (int i = 0; i < 100000; ++i) {
+    LogLevel level = Logger::getLevel();
+    (void)level;
+  }
+
+  auto end = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+  // 100000 level checks should be very fast (< 50ms)
+  EXPECT_LT(duration.count(), 50);
+}

--- a/tests/src/darabonba/test_Logger.cpp
+++ b/tests/src/darabonba/test_Logger.cpp
@@ -260,7 +260,7 @@ TEST_F(LoggerTest, ConcurrentSetLevel) {
 TEST_F(LoggerTest, ConcurrentLogging) {
   Logger::setLevel(LogLevel::DEBUG);
   const int numThreads = 10;
-  const int messagesPerThread = 100;
+  int messagesPerThread = 100;
   std::vector<std::thread> threads;
 
   for (int i = 0; i < numThreads; ++i) {

--- a/tests/src/darabonba/test_Number.cpp
+++ b/tests/src/darabonba/test_Number.cpp
@@ -76,3 +76,64 @@ TEST(Darabonba_Number, parseFloatScientificNotation) {
 TEST(Darabonba_Number, parseDoubleScientificNotation) {
   EXPECT_DOUBLE_EQ(Number::parseDouble("1.5e10"), 1.5e10);
 }
+
+// ==================== int64_t 大数值测试 ====================
+// 这些测试证明了使用 int64_t 和 std::stoll 而非 long 和 std::stol 的必要性
+// 在 Windows 平台上，long 是 32 位的，无法正确处理大于 INT32_MAX 的值
+
+// 测试 INT32_MAX (2147483647) - 在所有平台上都能正确处理
+TEST(Darabonba_Number, parseLongInt32Max) {
+  std::string val = "2147483647";  // INT32_MAX
+  int64_t result = Number::parseLong(val);
+  EXPECT_EQ(result, 2147483647LL);
+}
+
+// 测试 INT32_MAX + 1 - 在 32 位 long 平台（如 Windows）上会溢出
+// 如果使用 std::stol，这个测试在 Windows 上会失败
+TEST(Darabonba_Number, parseLongInt32MaxPlusOne) {
+  std::string val = "2147483648";  // INT32_MAX + 1
+  int64_t result = Number::parseLong(val);
+  EXPECT_EQ(result, 2147483648LL);  // 需要 int64_t 才能正确存储
+}
+
+// 测试大数值 - 证明 int64_t 可以处理超出 32 位范围的值
+TEST(Darabonba_Number, parseLongLargeValue) {
+  std::string val = "9223372036854775807";  // INT64_MAX
+  int64_t result = Number::parseLong(val);
+  EXPECT_EQ(result, 9223372036854775807LL);
+}
+
+// 测试 INT32_MIN - 1 - 负数边界
+TEST(Darabonba_Number, parseLongInt32MinMinusOne) {
+  std::string val = "-2147483649";  // INT32_MIN - 1
+  int64_t result = Number::parseLong(val);
+  EXPECT_EQ(result, -2147483649LL);
+}
+
+// 测试一个大时间戳（毫秒）- 实际应用场景
+// Unix 时间戳 2024-01-01 00:00:00 UTC 的毫秒值
+TEST(Darabonba_Number, parseLongTimestamp) {
+  std::string val = "1704067200000";  // 2024-01-01 00:00:00 UTC in milliseconds
+  int64_t result = Number::parseLong(val);
+  EXPECT_EQ(result, 1704067200000LL);
+  // 这个值远超 INT32_MAX，使用 long (32-bit) 会溢出
+  EXPECT_GT(result, 2147483647LL);  // 证明需要 int64_t
+}
+
+// 测试 itol 返回 int64_t
+TEST(Darabonba_Number, itolReturnsInt64) {
+  // 验证返回类型可以存储 int64_t 值
+  auto result = Number::itol(42);
+  static_assert(std::is_same<decltype(result), int64_t>::value,
+                "itol should return int64_t");
+  EXPECT_EQ(result, 42LL);
+}
+
+// 测试 ltoi 接受 int64_t
+TEST(Darabonba_Number, ltoiAcceptsInt64) {
+  // 验证可以接受 int64_t 参数
+  int64_t largeVal = 2147483648LL;  // INT32_MAX + 1
+  int result = Number::ltoi(largeVal);
+  // 注意：这里会发生截断，但函数签名应该接受 int64_t
+  EXPECT_EQ(result, static_cast<int>(largeVal));
+}

--- a/tests/src/darabonba/test_Retry.cpp
+++ b/tests/src/darabonba/test_Retry.cpp
@@ -336,6 +336,108 @@ TEST_F(RetryTest, RetryOptionsJsonSerialization) {
   EXPECT_EQ(options2.getRetryCondition().size(), 1u);
 }
 
+// ==================== retryable_ 字段 JSON 序列化测试 ====================
+// 这些测试证明了 retryable_ 字段被正确序列化和反序列化
+// 如果不添加这个字段到 to_json/from_json，retryable_ 值会丢失
+
+// 测试 retryable=true 被正确序列化和反序列化
+TEST_F(RetryTest, RetryOptionsRetryableFieldSerializationTrue) {
+  RetryOptions options;
+  options.setRetryable(true);
+
+  Json j;
+  to_json(j, options);
+
+  // 验证 retryable 字段被正确序列化
+  EXPECT_TRUE(j.contains("retryable"));
+  EXPECT_TRUE(j["retryable"].get<bool>());
+
+  // 验证反序列化
+  RetryOptions options2;
+  from_json(j, options2);
+  EXPECT_TRUE(options2.isRetryable());
+}
+
+// 测试 retryable=false 被正确序列化和反序列化
+TEST_F(RetryTest, RetryOptionsRetryableFieldSerializationFalse) {
+  RetryOptions options;
+  options.setRetryable(false);
+
+  Json j;
+  to_json(j, options);
+
+  // 验证 retryable 字段被正确序列化
+  EXPECT_TRUE(j.contains("retryable"));
+  EXPECT_FALSE(j["retryable"].get<bool>());
+
+  // 验证反序列化
+  RetryOptions options2;
+  from_json(j, options2);
+  EXPECT_FALSE(options2.isRetryable());
+}
+
+// 测试从 JSON 加载 retryable 字段
+TEST_F(RetryTest, RetryOptionsRetryableFieldFromJson) {
+  // 创建包含 retryable 字段的 JSON
+  Json j;
+  j["retryable"] = true;
+  j["retryCondition"] = Json::array();
+  j["noRetryCondition"] = Json::array();
+
+  RetryOptions options;
+  from_json(j, options);
+
+  EXPECT_TRUE(options.isRetryable());
+
+  // 测试 false 值
+  j["retryable"] = false;
+  RetryOptions options2;
+  from_json(j, options2);
+  EXPECT_FALSE(options2.isRetryable());
+}
+
+// 测试 JSON 中没有 retryable 字段时的默认行为
+TEST_F(RetryTest, RetryOptionsRetryableFieldDefaultWhenMissing) {
+  // 创建不包含 retryable 字段的 JSON
+  Json j;
+  j["retryCondition"] = Json::array();
+  j["noRetryCondition"] = Json::array();
+  // 注意：不设置 retryable 字段
+
+  RetryOptions options;
+  from_json(j, options);
+
+  // 默认值应该是 false
+  EXPECT_FALSE(options.isRetryable());
+}
+
+// 测试完整的 RetryOptions 往返序列化
+TEST_F(RetryTest, RetryOptionsRoundTripSerialization) {
+  RetryOptions original;
+  original.setRetryable(true);
+
+  RetryCondition condition;
+  condition.setMaxAttempts(5);
+  condition.setException({"ResponseException", "ServerException"});
+  original.setRetryCondition({condition});
+
+  // 序列化
+  Json j;
+  to_json(j, original);
+
+  // 反序列化
+  RetryOptions restored;
+  from_json(j, restored);
+
+  // 验证所有字段都被正确恢复
+  EXPECT_EQ(restored.isRetryable(), original.isRetryable());
+  EXPECT_EQ(restored.getRetryCondition().size(), original.getRetryCondition().size());
+  if (!restored.getRetryCondition().empty()) {
+    EXPECT_EQ(restored.getRetryCondition()[0].getMaxAttempts(),
+              original.getRetryCondition()[0].getMaxAttempts());
+  }
+}
+
 // Test RetryPolicyContext JSON serialization
 TEST_F(RetryTest, RetryPolicyContextJsonSerialization) {
   RetryPolicyContext ctx;

--- a/tests/src/darabonba/test_RuntimeOptions.cpp
+++ b/tests/src/darabonba/test_RuntimeOptions.cpp
@@ -1,0 +1,291 @@
+#include <darabonba/Runtime.hpp>
+#include <gtest/gtest.h>
+#include <memory>
+
+using namespace Darabonba;
+
+class RuntimeOptionsTest : public ::testing::Test {
+protected:
+  virtual void SetUp() override {}
+
+  virtual void TearDown() override {}
+};
+
+// ==================== maxIdleConns 字段测试 ====================
+// 测试新增的 maxIdleConns getter/setter
+
+TEST_F(RuntimeOptionsTest, MaxIdleConnsDefaultEmpty) {
+  RuntimeOptions options;
+  // 默认值应该是空字符串（因为 maxIdleConns_ 初始化为 nullptr 的字符串）
+  EXPECT_TRUE(options.getMaxIdleConns().empty());
+}
+
+TEST_F(RuntimeOptionsTest, MaxIdleConnsSetterGetter) {
+  RuntimeOptions options;
+  options.setMaxIdleConns("100");
+
+  EXPECT_EQ(options.getMaxIdleConns(), "100");
+}
+
+TEST_F(RuntimeOptionsTest, MaxIdleConnsSetEmpty) {
+  RuntimeOptions options;
+  options.setMaxIdleConns("");
+  EXPECT_TRUE(options.getMaxIdleConns().empty());
+}
+
+TEST_F(RuntimeOptionsTest, MaxIdleConnsOverwrite) {
+  RuntimeOptions options;
+  options.setMaxIdleConns("50");
+  EXPECT_EQ(options.getMaxIdleConns(), "50");
+
+  options.setMaxIdleConns("200");
+  EXPECT_EQ(options.getMaxIdleConns(), "200");
+}
+
+TEST_F(RuntimeOptionsTest, MaxIdleConnsLargeValue) {
+  RuntimeOptions options;
+  options.setMaxIdleConns("10000");
+  EXPECT_EQ(options.getMaxIdleConns(), "10000");
+}
+
+TEST_F(RuntimeOptionsTest, MaxIdleConnsStringValue) {
+  RuntimeOptions options;
+  // 测试字符串类型存储
+  options.setMaxIdleConns("invalid_number");
+  EXPECT_EQ(options.getMaxIdleConns(), "invalid_number");
+}
+
+// ==================== 其他 RuntimeOptions 字段测试 ====================
+
+TEST_F(RuntimeOptionsTest, AllTimeoutFields) {
+  RuntimeOptions options;
+  options.setReadTimeout(5000);
+  options.setConnectTimeout(3000);
+
+  EXPECT_EQ(options.getReadTimeout(), 5000);
+  EXPECT_EQ(options.getConnectTimeout(), 3000);
+}
+
+TEST_F(RuntimeOptionsTest, HttpProxySettings) {
+  RuntimeOptions options;
+  options.setHttpProxy("http://proxy.example.com:8080");
+  options.setHttpsProxy("https://proxy.example.com:8443");
+  options.setNoProxy("localhost,127.0.0.1");
+
+  EXPECT_EQ(options.getHttpProxy(), "http://proxy.example.com:8080");
+  EXPECT_EQ(options.getHttpsProxy(), "https://proxy.example.com:8443");
+  EXPECT_EQ(options.getNoProxy(), "localhost,127.0.0.1");
+}
+
+TEST_F(RuntimeOptionsTest, Socks5ProxySettings) {
+  RuntimeOptions options;
+  options.setSocks5Proxy("socks5://proxy.example.com:1080");
+  options.setSocks5NetWork("tcp");
+
+  EXPECT_EQ(options.getSocks5Proxy(), "socks5://proxy.example.com:1080");
+  EXPECT_EQ(options.getSocks5NetWork(), "tcp");
+}
+
+TEST_F(RuntimeOptionsTest, SslSettings) {
+  RuntimeOptions options;
+  options.setKey("/path/to/key.pem");
+  options.setCert("/path/to/cert.pem");
+  options.setCa("/path/to/ca.pem");
+  options.setIgnoreSSL(true);
+
+  EXPECT_EQ(options.getKey(), "/path/to/key.pem");
+  EXPECT_EQ(options.getCert(), "/path/to/cert.pem");
+  EXPECT_EQ(options.getCa(), "/path/to/ca.pem");
+  EXPECT_TRUE(options.getIgnoreSSL());
+}
+
+TEST_F(RuntimeOptionsTest, ConnectionSettings) {
+  RuntimeOptions options;
+  options.setMaxConnections(100);
+  options.setMaxHostConnections(10);
+  options.setKeepAlive(true);
+  options.setLocalAddr("192.168.1.100");
+
+  EXPECT_EQ(options.getMaxConnections(), 100);
+  EXPECT_EQ(options.getMaxHostConnections(), 10);
+  EXPECT_TRUE(options.getKeepAlive());
+  EXPECT_EQ(options.getLocalAddr(), "192.168.1.100");
+}
+
+TEST_F(RuntimeOptionsTest, BackoffSettings) {
+  RuntimeOptions options;
+  options.setMaxAttempts(5);
+  options.setBackoffPolicy("Exponential");
+  options.setBackoffPeriod(1000);
+
+  EXPECT_EQ(options.getMaxAttempts(), 5);
+  EXPECT_EQ(options.getBackoffPolicy(), "Exponential");
+  EXPECT_EQ(options.getBackoffPeriod(), 1000);
+}
+
+TEST_F(RuntimeOptionsTest, AutoretrySetting) {
+  RuntimeOptions options;
+  options.setAutoretry(true);
+  EXPECT_TRUE(options.getAutoretry());
+
+  options.setAutoretry(false);
+  EXPECT_FALSE(options.getAutoretry());
+}
+
+// ==================== ExtendsParameters 测试 ====================
+
+TEST_F(RuntimeOptionsTest, ExtendsParametersSetGet) {
+  RuntimeOptions options;
+  ExtendsParameters params;
+
+  std::map<std::string, std::string> headers;
+  headers["X-Custom-Header"] = "value";
+  params.setHeaders(headers);
+
+  std::map<std::string, std::string> queries;
+  queries["param"] = "query_value";
+  params.setQueries(queries);
+
+  options.setExtendsParameters(params);
+
+  EXPECT_TRUE(options.hasExtendsParameters());
+  EXPECT_EQ(options.getExtendsParameters().getHeaders().at("X-Custom-Header"), "value");
+  EXPECT_EQ(options.getExtendsParameters().getQueries().at("param"), "query_value");
+}
+
+TEST_F(RuntimeOptionsTest, ExtendsParametersDelete) {
+  RuntimeOptions options;
+  ExtendsParameters params;
+  params.setHeaders({{"X-Test", "value"}});
+  options.setExtendsParameters(params);
+
+  EXPECT_TRUE(options.hasExtendsParameters());
+  options.deleteExtendsParameters();
+  EXPECT_FALSE(options.hasExtendsParameters());
+}
+
+// ==================== RetryOptions 测试 ====================
+
+TEST_F(RuntimeOptionsTest, RetryOptionsSetGet) {
+  RuntimeOptions options;
+  Policy::RetryOptions retryOptions;
+  retryOptions.setRetryable(true);
+
+  options.setRetryOptions(retryOptions);
+
+  EXPECT_TRUE(options.hasRetryOptions());
+  EXPECT_TRUE(options.getRetryOptions().isRetryable());
+}
+
+TEST_F(RuntimeOptionsTest, RetryOptionsDelete) {
+  RuntimeOptions options;
+  Policy::RetryOptions retryOptions;
+  retryOptions.setRetryable(true);
+  options.setRetryOptions(retryOptions);
+
+  EXPECT_TRUE(options.hasRetryOptions());
+  options.deleteRetryOptions();
+  EXPECT_FALSE(options.hasRetryOptions());
+}
+
+// ==================== JSON 序列化测试 ====================
+
+TEST_F(RuntimeOptionsTest, JsonSerializationBasicFields) {
+  RuntimeOptions options;
+  options.setReadTimeout(5000);
+  options.setConnectTimeout(3000);
+  options.setIgnoreSSL(true);
+  options.setHttpProxy("http://proxy:8080");
+
+  Json j;
+  to_json(j, options);
+
+  EXPECT_EQ(j["readTimeout"], 5000);
+  EXPECT_EQ(j["connectTimeout"], 3000);
+  EXPECT_EQ(j["ignoreSSL"], true);
+  EXPECT_EQ(j["httpProxy"], "http://proxy:8080");
+}
+
+TEST_F(RuntimeOptionsTest, JsonDeserializationBasicFields) {
+  Json j;
+  j["readTimeout"] = 5000;
+  j["connectTimeout"] = 3000;
+  j["ignoreSSL"] = true;
+  j["httpProxy"] = "http://proxy:8080";
+
+  RuntimeOptions options;
+  from_json(j, options);
+
+  EXPECT_EQ(options.getReadTimeout(), 5000);
+  EXPECT_EQ(options.getConnectTimeout(), 3000);
+  EXPECT_TRUE(options.getIgnoreSSL());
+  EXPECT_EQ(options.getHttpProxy(), "http://proxy:8080");
+}
+
+TEST_F(RuntimeOptionsTest, JsonRoundTrip) {
+  RuntimeOptions original;
+  original.setReadTimeout(5000);
+  original.setConnectTimeout(3000);
+  original.setIgnoreSSL(true);
+  original.setMaxConnections(100);
+  original.setKeepAlive(true);
+
+  Json j;
+  to_json(j, original);
+
+  RuntimeOptions restored;
+  from_json(j, restored);
+
+  EXPECT_EQ(restored.getReadTimeout(), original.getReadTimeout());
+  EXPECT_EQ(restored.getConnectTimeout(), original.getConnectTimeout());
+  EXPECT_EQ(restored.getIgnoreSSL(), original.getIgnoreSSL());
+  EXPECT_EQ(restored.getMaxConnections(), original.getMaxConnections());
+  EXPECT_EQ(restored.getKeepAlive(), original.getKeepAlive());
+}
+
+// ==================== empty() 方法测试 ====================
+
+TEST_F(RuntimeOptionsTest, EmptyWhenDefault) {
+  RuntimeOptions options;
+  EXPECT_TRUE(options.empty());
+}
+
+TEST_F(RuntimeOptionsTest, NotEmptyWhenFieldSet) {
+  RuntimeOptions options;
+  options.setReadTimeout(5000);
+  EXPECT_FALSE(options.empty());
+}
+
+TEST_F(RuntimeOptionsTest, EmptyAfterClear) {
+  RuntimeOptions options;
+  options.setReadTimeout(5000);
+  options.deleteReadTimeout();
+  EXPECT_TRUE(options.empty());
+}
+
+// ==================== 边界情况测试 ====================
+
+TEST_F(RuntimeOptionsTest, ZeroTimeoutValues) {
+  RuntimeOptions options;
+  options.setReadTimeout(0);
+  options.setConnectTimeout(0);
+
+  EXPECT_EQ(options.getReadTimeout(), 0);
+  EXPECT_EQ(options.getConnectTimeout(), 0);
+}
+
+TEST_F(RuntimeOptionsTest, LargeTimeoutValues) {
+  RuntimeOptions options;
+  options.setReadTimeout(INT64_MAX);
+  options.setConnectTimeout(INT64_MAX);
+
+  EXPECT_EQ(options.getReadTimeout(), INT64_MAX);
+  EXPECT_EQ(options.getConnectTimeout(), INT64_MAX);
+}
+
+TEST_F(RuntimeOptionsTest, NegativeValues) {
+  RuntimeOptions options;
+  // 虽然 API 可能不接受负值，但类型应该能存储
+  options.setReadTimeout(-1);
+  EXPECT_EQ(options.getReadTimeout(), -1);
+}

--- a/tests/src/darabonba/test_Stream.cpp
+++ b/tests/src/darabonba/test_Stream.cpp
@@ -165,10 +165,8 @@ TEST_F(StreamTest, ToWritableFromString) {
 
 // ==================== readFromFilePath 测试 ====================
 TEST_F(StreamTest, ReadFromFilePathWithNonExistentFile) {
-  auto stream = Stream::readFromFilePath("/non/existent/path/file.txt");
-
-  // 文件不存在，但流对象应该被创建
-  EXPECT_NE(stream, nullptr);
+  // 文件不存在时应抛出异常
+  EXPECT_THROW(Stream::readFromFilePath("/non/existent/path/file.txt"), Darabonba::DaraException);
 }
 
 // ==================== readFromBytes 测试 ====================

--- a/tests/src/darabonba/test_Time.cpp
+++ b/tests/src/darabonba/test_Time.cpp
@@ -1,5 +1,6 @@
 #include <darabonba/Time.hpp>
 #include <chrono>
+#include <cstdint>
 #include <gtest/gtest.h>
 #include <regex>
 
@@ -10,7 +11,7 @@ TEST(Darabonba_Time, unixReturnsTimestamp) {
   std::string ts = Time::unix();
   EXPECT_FALSE(ts.empty());
   // 应该是一个正整数
-  long val = std::stol(ts);
+  int64_t val = std::stoll(ts);
   EXPECT_GT(val, 1000000000L); // 大于 2001-09-09
 }
 
@@ -19,7 +20,7 @@ TEST(Darabonba_Time, unixIsReasonable) {
   auto epoch = std::chrono::duration_cast<std::chrono::seconds>(
                    now.time_since_epoch())
                    .count();
-  long ts = std::stol(Time::unix());
+  int64_t ts = std::stoll(Time::unix());
   // 应该跟当前时间相差不超过 2 秒
   EXPECT_LE(std::abs(ts - epoch), 2);
 }

--- a/tests/src/darabonba/test_Type.cpp
+++ b/tests/src/darabonba/test_Type.cpp
@@ -1,0 +1,94 @@
+#include <darabonba/Type.hpp>
+#include <gtest/gtest.h>
+#include <string>
+
+using namespace Darabonba;
+
+// 测试 DARA_STRING_TEMPLATE 对普通字符串类型的兼容性
+TEST(DaraStringTemplate, BasicStringConcatenation) {
+  std::string prefix = "pre";
+  std::string suffix = "suf";
+  
+  EXPECT_EQ(DARA_STRING_TEMPLATE(prefix, suffix), "presuf");
+  EXPECT_EQ(DARA_STRING_TEMPLATE("hello", " ", "world"), "hello world");
+  EXPECT_EQ(DARA_STRING_TEMPLATE("", "middle", ""), "middle");
+}
+
+// 测试 DARA_STRING_TEMPLATE 对 int 类型的支持
+TEST(DaraStringTemplate, IntConcatenation) {
+  int num = 123;
+  EXPECT_EQ(DARA_STRING_TEMPLATE("value:", num), "value:123");
+  EXPECT_EQ(DARA_STRING_TEMPLATE(num, " items"), "123 items");
+}
+
+// 测试 DARA_STRING_TEMPLATE 对 json 字符串类型的处理（核心修复点）
+TEST(DaraStringTemplate, JsonStringValueWithoutQuotes) {
+  Json strJson = "oss-cn-shanghai.aliyuncs.com";
+  
+  // 关键测试：json 字符串类型应该输出值本身，而不是带引号的 JSON 格式
+  EXPECT_EQ(DARA_STRING_TEMPLATE("bucket.", strJson), "bucket.oss-cn-shanghai.aliyuncs.com");
+  EXPECT_EQ(DARA_STRING_TEMPLATE(strJson), "oss-cn-shanghai.aliyuncs.com");
+  
+  // 模拟真实 SDK 使用场景
+  std::string bucketName = "sh-imagesearch-transfer-station";
+  Json hostJson = "oss-cn-shanghai.aliyuncs.com";
+  EXPECT_EQ(DARA_STRING_TEMPLATE("", bucketName, ".", hostJson), 
+            "sh-imagesearch-transfer-station.oss-cn-shanghai.aliyuncs.com");
+}
+
+// 测试 DARA_STRING_TEMPLATE 对 json 数字类型的处理
+TEST(DaraStringTemplate, JsonNumberValue) {
+  Json numJson = 42;
+  
+  // 数字类型应该正常输出数值
+  EXPECT_EQ(DARA_STRING_TEMPLATE("count:", numJson), "count:42");
+}
+
+// 测试 DARA_STRING_TEMPLATE 对 json 对象类型的处理
+TEST(DaraStringTemplate, JsonObjectValue) {
+  Json objJson = Json::object({{"key", "value"}});
+  
+  // 对象类型应该输出 JSON 格式（因为不是字符串类型）
+  EXPECT_EQ(DARA_STRING_TEMPLATE("data:", objJson), "data:{\"key\":\"value\"}");
+}
+
+// 测试 DARA_STRING_TEMPLATE 对 json 数组类型的处理
+TEST(DaraStringTemplate, JsonArrayValue) {
+  Json arrJson = Json::array({"a", "b", "c"});
+  
+  // 数组类型应该输出 JSON 格式
+  EXPECT_EQ(DARA_STRING_TEMPLATE("items:", arrJson), "items:[\"a\",\"b\",\"c\"]");
+}
+
+// 测试混合类型拼接
+TEST(DaraStringTemplate, MixedTypes) {
+  std::string prefix = "result=";
+  Json strJson = "success";
+  int code = 200;
+  
+  EXPECT_EQ(DARA_STRING_TEMPLATE(prefix, strJson, ", code=", code), 
+            "result=success, code=200");
+}
+
+// 测试空 json 字符串
+TEST(DaraStringTemplate, EmptyJsonString) {
+  Json emptyStr = "";
+  
+  EXPECT_EQ(DARA_STRING_TEMPLATE("prefix", emptyStr, "suffix"), "prefixsuffix");
+}
+
+// 测试 json null 类型
+TEST(DaraStringTemplate, JsonNullValue) {
+  Json nullJson = nullptr;
+  
+  EXPECT_EQ(DARA_STRING_TEMPLATE("value:", nullJson), "value:null");
+}
+
+// 测试 json boolean 类型
+TEST(DaraStringTemplate, JsonBoolValue) {
+  Json trueJson = true;
+  Json falseJson = false;
+  
+  EXPECT_EQ(DARA_STRING_TEMPLATE("flag=", trueJson), "flag=true");
+  EXPECT_EQ(DARA_STRING_TEMPLATE("flag=", falseJson), "flag=false");
+}

--- a/tests/test_fromMap.cpp
+++ b/tests/test_fromMap.cpp
@@ -1,0 +1,65 @@
+#include <iostream>
+#include <darabonba/Core.hpp>
+#include <darabonba/Model.hpp>
+
+using namespace Darabonba;
+
+// 测试模型
+class TestResponse : public Model {
+public:
+  std::shared_ptr<std::string> name_;
+  std::shared_ptr<int32_t> count_;
+  
+  friend void from_json(const Json& j, TestResponse& obj) {
+    DARABONBA_PTR_FROM_JSON(name, name_);
+    DARABONBA_PTR_FROM_JSON(count, count_);
+  }
+  
+  Json toMap() const override {
+    Json j;
+    if (name_) j["name"] = *name_;
+    if (count_) j["count"] = *count_;
+    return j;
+  }
+  
+  void fromMap(const Json& j) override {
+    from_json(j, *this);
+  }
+  
+  void validate() const override {}
+  bool empty() const override { return !name_ && !count_; }
+  
+  // Getters
+  std::string getName() const { return name_ ? *name_ : ""; }
+  int32_t getCount() const { return count_ ? *count_ : 0; }
+};
+
+int main() {
+  std::cout << "=== Darabonba::fromMap 函数测试 ===\n\n";
+  
+  // 测试 1: 基本使用
+  std::cout << "【测试 1: 基本使用】\n";
+  Json j1 = {{"name", "test"}, {"count", 42}};
+  TestResponse resp1 = fromMap<TestResponse>(j1);
+  std::cout << "  name: " << resp1.getName() << "\n";
+  std::cout << "  count: " << resp1.getCount() << "\n";
+  std::cout << "  ✅ fromMap<T>() 工作正常\n\n";
+  
+  // 测试 2: 类型转换（string -> int）
+  std::cout << "【测试 2: 类型转换（string -> int）】\n";
+  Json j2 = {{"name", "convert"}, {"count", "100"}};
+  TestResponse resp2 = fromMap<TestResponse>(j2);
+  std::cout << "  count: \"100\" → " << resp2.getCount() << "\n";
+  std::cout << "  ✅ string -> int 转换成功\n\n";
+  
+  // 测试 3: fromMapPtr
+  std::cout << "【测试 3: fromMapPtr】\n";
+  Json j3 = {{"name", "pointer"}, {"count", 999}};
+  auto ptr = fromMapPtr<TestResponse>(j3);
+  std::cout << "  name: " << ptr->getName() << "\n";
+  std::cout << "  count: " << ptr->getCount() << "\n";
+  std::cout << "  ✅ fromMapPtr<T>() 工作正常\n\n";
+  
+  std::cout << "✅ 所有测试通过！fromMap 函数可用！\n";
+  return 0;
+}


### PR DESCRIPTION
- 在ConnectionPoolConfig中添加keep_alive字段，默认启用TCP keep-alive
- 为MCurlHttpClient添加setConnectionPoolConfig和getConnectionPoolConfig方法
- 实现applyConnectionPoolSettings方法来应用连接池设置到curl多句柄
- 修改getConnectionPoolConfig函数从运行时读取maxIdleConns和keepAlive配置
- 在Core::doAction中为新客户端应用连接池配置，并更新现有客户端配置
- 为MCurlHttpClient中的easy handle设置TCP keep-alive相关选项
- 将Stream::readAsString中的cleanString调用移除，直接返回字符串
- 为MCurlHttpClient添加默认readTimeout设置为10秒
- 添加大量单元测试验证连接池配置功能