### PR TITLE
[C++ V2] Map SOCKS5 proxy runtime options

### DIFF
--- a/include/darabonba/Core.hpp
+++ b/include/darabonba/Core.hpp
@@ -59,6 +59,8 @@ struct RequestConfig {
   std::string http_proxy;            // Per-request proxy
   std::string https_proxy;           // Per-request HTTPS proxy
   std::string no_proxy;              // Per-request no-proxy list
+  std::string socks5_proxy;          // Per-request SOCKS5 proxy
+  std::string socks5_network;        // Per-request SOCKS5 network (tcp/udp)
   std::string credential;            // Per-request credentials
 };
 

--- a/include/darabonba/http/Curl.hpp
+++ b/include/darabonba/http/Curl.hpp
@@ -30,6 +30,20 @@ void setCurlRequestBody(CURL *curl, std::shared_ptr<Darabonba::IStream> body);
 
 void setCurlProxy(CURL *curl, const std::string &proxy);
 
+void setCurlSocks5Proxy(CURL *curl, const std::string &proxy,
+                        const std::string &network);
+
+void validateProxyOptions(const std::string &httpProxy,
+                          const std::string &httpsProxy,
+                          const std::string &socks5Proxy,
+                          const std::string &socks5Network);
+
+void applyCurlProxyOptions(CURL *curl, const std::string &httpProxy,
+                           const std::string &httpsProxy,
+                           const std::string &socks5Proxy,
+                           const std::string &socks5Network,
+                           const std::string &noProxy);
+
 curl_slist *setCurlHeader(CURL *curl, const Darabonba::Http::Header &header);
 
 int debugFunction(CURL *curl, curl_infotype type, char *data, size_t size,

--- a/src/darabonba/Core.cpp
+++ b/src/darabonba/Core.cpp
@@ -123,6 +123,12 @@ RequestConfig getRequestConfig(const Darabonba::Json &runtime) {
     if (runtime.contains("noProxy")) {
       config.no_proxy = runtime["noProxy"].get<std::string>();
     }
+    if (runtime.contains("socks5Proxy")) {
+      config.socks5_proxy = runtime["socks5Proxy"].get<std::string>();
+    }
+    if (runtime.contains("socks5NetWork")) {
+      config.socks5_network = runtime["socks5NetWork"].get<std::string>();
+    }
     if (runtime.contains("credential")) {
       config.credential = runtime["credential"].get<std::string>();
     }
@@ -230,6 +236,8 @@ Core::doAction(Http::Request &request, const Darabonba::Json &runtime) {
   request_runtime["httpProxy"] = request_config.http_proxy;
   request_runtime["httpsProxy"] = request_config.https_proxy;
   request_runtime["noProxy"] = request_config.no_proxy;
+  request_runtime["socks5Proxy"] = request_config.socks5_proxy;
+  request_runtime["socks5NetWork"] = request_config.socks5_network;
 
   // makeRequest is now called without holding the global lock,
   // allowing concurrent requests to different hosts

--- a/src/darabonba/http/Curl.cpp
+++ b/src/darabonba/http/Curl.cpp
@@ -1,8 +1,11 @@
 #include <darabonba/Stream.hpp>
+#include <darabonba/Exception.hpp>
 #include <darabonba/http/Curl.hpp>
 #include <darabonba/http/Form.hpp>
 #include <darabonba/http/URL.hpp>
 #include <memory>
+#include <algorithm>
+#include <cctype>
 
 namespace Darabonba {
 namespace Http {
@@ -96,12 +99,142 @@ size_t readIStream(char *buffer, size_t size, size_t nitems, void *userdata) {
   return f->read(buffer, size * nitems);
 }
 
+namespace {
+
+std::string normalizeNetworkToken(const std::string &network) {
+  std::string value = network;
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+std::string stripSocksScheme(std::string proxy) {
+  static const char *prefixes[] = {"socks5h://", "socks5://", "socks4a://",
+                                   "socks4://"};
+  for (const auto *prefix : prefixes) {
+    const std::string scheme(prefix);
+    if (proxy.size() >= scheme.size() &&
+        std::equal(scheme.begin(), scheme.end(), proxy.begin(),
+                   [](char a, char b) {
+                     return std::tolower(static_cast<unsigned char>(a)) ==
+                            std::tolower(static_cast<unsigned char>(b));
+                   })) {
+      return proxy.substr(scheme.size());
+    }
+  }
+  return proxy;
+}
+
+URL parseProxyEndpoint(const std::string &proxy) {
+  std::string endpoint = stripSocksScheme(proxy);
+  if (endpoint.find("://") == std::string::npos) {
+    endpoint = "http://" + endpoint;
+  }
+  return URL(endpoint);
+}
+
+bool usesRemoteDnsResolution(const std::string &proxy) {
+  std::string lower = proxy;
+  std::transform(lower.begin(), lower.end(), lower.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return lower.rfind("socks5h://", 0) == 0;
+}
+
+} // namespace
+
 void setCurlProxy(CURL *curl, const std::string &proxy) {
-  URL url(proxy);
-  std::string out = url.getHost() + ":" + std::to_string(url.getPort());
+  URL url(parseProxyEndpoint(proxy));
+  if (url.getHost().empty()) {
+    throw ValidateException("InvalidConfiguration",
+                            "Invalid proxy URL: " + proxy);
+  }
+  uint16_t port = url.getPort();
+  if (port == 0) {
+    port = 1080;
+  }
+  std::string out = url.getHost() + ":" + std::to_string(port);
   curl_easy_setopt(curl, CURLOPT_PROXY, out.c_str());
   if (!url.getUserInfo().empty()) {
     curl_easy_setopt(curl, CURLOPT_PROXYUSERPWD, url.getUserInfo().c_str());
+  }
+}
+
+void validateProxyOptions(const std::string &httpProxy,
+                          const std::string &httpsProxy,
+                          const std::string &socks5Proxy,
+                          const std::string &socks5Network) {
+  if (!socks5Network.empty() && socks5Proxy.empty()) {
+    throw ValidateException("InvalidConfiguration",
+                          "socks5NetWork requires socks5Proxy to be configured");
+  }
+
+  if (!socks5Network.empty()) {
+    const std::string network = normalizeNetworkToken(socks5Network);
+    if (network != "tcp" && network != "udp") {
+      throw ValidateException("InvalidConfiguration",
+                              "Invalid socks5NetWork: " + socks5Network +
+                                  ", expected tcp or udp");
+    }
+    if (network == "udp") {
+      throw ValidateException(
+          "InvalidConfiguration",
+          "SOCKS5 UDP network is not supported for HTTP requests");
+    }
+  }
+
+  if (!socks5Proxy.empty()) {
+    URL url(parseProxyEndpoint(socks5Proxy));
+    if (url.getHost().empty()) {
+      throw ValidateException("InvalidConfiguration",
+                              "Invalid socks5Proxy: " + socks5Proxy);
+    }
+  }
+
+  if (!httpProxy.empty()) {
+    URL url(parseProxyEndpoint(httpProxy));
+    if (url.getHost().empty()) {
+      throw ValidateException("InvalidConfiguration",
+                              "Invalid httpProxy: " + httpProxy);
+    }
+  }
+
+  if (!httpsProxy.empty()) {
+    URL url(parseProxyEndpoint(httpsProxy));
+    if (url.getHost().empty()) {
+      throw ValidateException("InvalidConfiguration",
+                              "Invalid httpsProxy: " + httpsProxy);
+    }
+  }
+}
+
+void setCurlSocks5Proxy(CURL *curl, const std::string &proxy,
+                        const std::string &network) {
+  (void)network;
+  const bool remoteDns = usesRemoteDnsResolution(proxy);
+  curl_easy_setopt(curl, CURLOPT_PROXYTYPE,
+                   remoteDns ? CURLPROXY_SOCKS5_HOSTNAME : CURLPROXY_SOCKS5);
+  setCurlProxy(curl, proxy);
+}
+
+void applyCurlProxyOptions(CURL *curl, const std::string &httpProxy,
+                           const std::string &httpsProxy,
+                           const std::string &socks5Proxy,
+                           const std::string &socks5Network,
+                           const std::string &noProxy) {
+  validateProxyOptions(httpProxy, httpsProxy, socks5Proxy, socks5Network);
+
+  if (!noProxy.empty()) {
+    curl_easy_setopt(curl, CURLOPT_NOPROXY, noProxy.c_str());
+  }
+
+  if (!httpProxy.empty()) {
+    curl_easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+    setCurlProxy(curl, httpProxy);
+  } else if (!httpsProxy.empty()) {
+    curl_easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTPS);
+    setCurlProxy(curl, httpsProxy);
+  } else if (!socks5Proxy.empty()) {
+    setCurlSocks5Proxy(curl, socks5Proxy, socks5Network);
   }
 }
 

--- a/src/darabonba/http/MCurlHttpClient.cpp
+++ b/src/darabonba/http/MCurlHttpClient.cpp
@@ -72,21 +72,13 @@ MCurlHttpClient::makeRequest(const Request &request,
       curl_easy_setopt(easyHandle, CURLOPT_TIMEOUT_MS, readTimeout);
     }
     // set proxy
-    // TODO: sock5
     std::string httpProxy = options.value("httpProxy", "");
-    if (!httpProxy.empty()) {
-      curl_easy_setopt(easyHandle, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
-      Curl::setCurlProxy(easyHandle, httpProxy);
-    }
     std::string httpsProxy = options.value("httpsProxy", "");
-    if (!httpsProxy.empty()) {
-      curl_easy_setopt(easyHandle, CURLOPT_PROXYTYPE, CURLPROXY_HTTPS);
-      Curl::setCurlProxy(easyHandle, httpsProxy);
-    }
+    std::string socks5Proxy = options.value("socks5Proxy", "");
+    std::string socks5NetWork = options.value("socks5NetWork", "");
     std::string noProxy = options.value("noProxy", "");
-    if (!noProxy.empty()) {
-      curl_easy_setopt(easyHandle, CURLOPT_NOPROXY, noProxy.c_str());
-    }
+    Curl::applyCurlProxyOptions(easyHandle, httpProxy, httpsProxy, socks5Proxy,
+                                socks5NetWork, noProxy);
   }
 
   if (nullptr != getenv("DEBUG")) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,20 @@ target_include_directories(${PROJECT_NAME}Test
 # googletest - gtest_main already includes gtest transitively
 target_link_libraries(${PROJECT_NAME}Test ${PROJECT_NAME} gtest_main gmock)
 
+# Prefer bundled GoogleTest headers over system installs (e.g. Homebrew).
+if(TARGET gtest)
+  get_target_property(_gtest_include_dirs gtest INTERFACE_INCLUDE_DIRECTORIES)
+  if(_gtest_include_dirs)
+    target_include_directories(${PROJECT_NAME}Test BEFORE PRIVATE ${_gtest_include_dirs})
+  endif()
+endif()
+if(TARGET gmock)
+  get_target_property(_gmock_include_dirs gmock INTERFACE_INCLUDE_DIRECTORIES)
+  if(_gmock_include_dirs)
+    target_include_directories(${PROJECT_NAME}Test BEFORE PRIVATE ${_gmock_include_dirs})
+  endif()
+endif()
+
 # On Windows with shared libs, copy the DLL to the test executable directory
 if(WIN32 AND BUILD_SHARED_LIBS)
   add_custom_command(TARGET ${PROJECT_NAME}Test POST_BUILD

--- a/tests/src/darabonba/http/test_CurlProxy.cpp
+++ b/tests/src/darabonba/http/test_CurlProxy.cpp
@@ -1,0 +1,143 @@
+#include <darabonba/Exception.hpp>
+#include <darabonba/http/Curl.hpp>
+#include <darabonba/http/MCurlHttpClient.hpp>
+#include <darabonba/http/Request.hpp>
+#include <curl/curl.h>
+#include <gtest/gtest.h>
+
+using namespace Darabonba;
+using namespace Darabonba::Http;
+using namespace Darabonba::Http::Curl;
+
+class CurlProxyTest : public ::testing::Test {};
+
+TEST_F(CurlProxyTest, ValidateSocks5NetworkWithoutProxyFailsFast) {
+  EXPECT_THROW(validateProxyOptions("", "", "", "tcp"), ValidateException);
+}
+
+TEST_F(CurlProxyTest, ValidateInvalidSocks5NetworkFailsFast) {
+  EXPECT_THROW(validateProxyOptions("", "", "socks5://127.0.0.1:1080", "icmp"),
+               ValidateException);
+}
+
+TEST_F(CurlProxyTest, ValidateSocks5UdpFailsFast) {
+  EXPECT_THROW(validateProxyOptions("", "", "socks5://127.0.0.1:1080", "udp"),
+               ValidateException);
+}
+
+TEST_F(CurlProxyTest, ValidateInvalidSocks5ProxyFailsFast) {
+  EXPECT_THROW(validateProxyOptions("", "", "# #%gfdf", ""), ValidateException);
+}
+
+TEST_F(CurlProxyTest, ValidateInvalidHttpProxyFailsFast) {
+  EXPECT_THROW(validateProxyOptions("://bad", "", "", ""), ValidateException);
+}
+
+TEST_F(CurlProxyTest, ValidateInvalidHttpsProxyFailsFast) {
+  EXPECT_THROW(validateProxyOptions("", "://bad", "", ""), ValidateException);
+}
+
+TEST_F(CurlProxyTest, ValidateValidSocks5ProxyPasses) {
+  EXPECT_NO_THROW(validateProxyOptions("", "", "socks5://user:pass@127.0.0.1:1080",
+                                       "tcp"));
+}
+
+TEST_F(CurlProxyTest, ValidateValidHttpProxyPasses) {
+  EXPECT_NO_THROW(validateProxyOptions("http://127.0.0.1:8080", "", "", ""));
+}
+
+TEST_F(CurlProxyTest, ValidateValidHttpsProxyPasses) {
+  EXPECT_NO_THROW(validateProxyOptions("", "https://127.0.0.1:8443", "", ""));
+}
+
+TEST_F(CurlProxyTest, ApplyCurlProxyOptionsHttpBranch) {
+  CURL *curl = curl_easy_init();
+  ASSERT_NE(curl, nullptr);
+  EXPECT_NO_THROW(applyCurlProxyOptions(curl, "http://127.0.0.1:8080", "", "",
+                                        "", "localhost"));
+  curl_easy_cleanup(curl);
+}
+
+TEST_F(CurlProxyTest, ApplyCurlProxyOptionsHttpsBranch) {
+  CURL *curl = curl_easy_init();
+  ASSERT_NE(curl, nullptr);
+  EXPECT_NO_THROW(applyCurlProxyOptions(curl, "", "https://127.0.0.1:8443", "",
+                                        "", ""));
+  curl_easy_cleanup(curl);
+}
+
+TEST_F(CurlProxyTest, ApplyCurlProxyOptionsSocks5hBranch) {
+  CURL *curl = curl_easy_init();
+  ASSERT_NE(curl, nullptr);
+  EXPECT_NO_THROW(applyCurlProxyOptions(curl, "", "", "socks5h://127.0.0.1:1080",
+                                        "tcp", ""));
+  curl_easy_cleanup(curl);
+}
+
+TEST_F(CurlProxyTest, ApplyCurlProxyOptionsHttpPriorityOverSocks5) {
+  CURL *curl = curl_easy_init();
+  ASSERT_NE(curl, nullptr);
+  EXPECT_NO_THROW(applyCurlProxyOptions(
+      curl, "http://127.0.0.1:8080", "", "socks5://127.0.0.1:1080", "tcp", ""));
+  curl_easy_cleanup(curl);
+}
+
+TEST_F(CurlProxyTest, MakeRequestAppliesSocks5OptionsBeforeNetworkIO) {
+  MCurlHttpClient client;
+  client.start();
+
+  Request request("https://www.example.com");
+  Darabonba::Json options;
+  options["socks5Proxy"] = "socks5://127.0.0.1:1080";
+  options["socks5NetWork"] = "tcp";
+  options["noProxy"] = "localhost";
+  options["connectTimeout"] = 1000L;
+  options["readTimeout"] = 1000L;
+
+  auto future = client.makeRequest(request, options);
+  auto status = future.wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready);
+
+  try {
+    (void)future.get();
+  } catch (const std::exception &) {
+    // Connection failure against local proxy is acceptable; config was accepted.
+  }
+
+  client.stop();
+}
+
+TEST_F(CurlProxyTest, MakeRequestRejectsInvalidSocks5Configuration) {
+  MCurlHttpClient client;
+  client.start();
+
+  Request request("https://www.example.com");
+  Darabonba::Json options;
+  options["socks5NetWork"] = "tcp";
+
+  EXPECT_THROW(client.makeRequest(request, options), ValidateException);
+
+  client.stop();
+}
+
+TEST_F(CurlProxyTest, MakeRequestAppliesHttpProxyBeforeNetworkIO) {
+  MCurlHttpClient client;
+  client.start();
+
+  Request request("https://www.example.com");
+  Darabonba::Json options;
+  options["httpProxy"] = "http://127.0.0.1:8080";
+  options["connectTimeout"] = 1000L;
+  options["readTimeout"] = 1000L;
+
+  auto future = client.makeRequest(request, options);
+  auto status = future.wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready);
+
+  try {
+    (void)future.get();
+  } catch (const std::exception &) {
+  }
+
+  client.stop();
+}

--- a/tests/src/darabonba/test_Core.cpp
+++ b/tests/src/darabonba/test_Core.cpp
@@ -681,6 +681,39 @@ TEST_F(CoreTest, EmptyRuntimeOptions) {
   }
 }
 
+// ==================== SOCKS5 proxy runtime 测试 ====================
+TEST_F(CoreTest, DoActionRejectsSocks5NetworkWithoutProxy) {
+  Http::Request request(std::string("https://www.example.com"));
+
+  Json runtime;
+  runtime["socks5NetWork"] = "tcp";
+  runtime["connectTimeout"] = 1000L;
+  runtime["readTimeout"] = 1000L;
+
+  EXPECT_THROW(core.doAction(request, runtime), ValidateException);
+}
+
+TEST_F(CoreTest, DoActionAcceptsSocks5RuntimeOptions) {
+  Http::Request request(std::string("https://www.example.com"));
+
+  Json runtime;
+  runtime["socks5Proxy"] = "socks5://127.0.0.1:1080";
+  runtime["socks5NetWork"] = "tcp";
+  runtime["noProxy"] = "localhost";
+  runtime["connectTimeout"] = 1000L;
+  runtime["readTimeout"] = 1000L;
+
+  auto future = core.doAction(request, runtime);
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(5)),
+            std::future_status::ready);
+
+  try {
+    (void)future.get();
+  } catch (const std::exception &) {
+    // Local proxy may be unavailable; configuration path was exercised.
+  }
+}
+
 // ==================== 配置类型安全测试 ====================
 TEST_F(CoreTest, MaxIdleConnsTypeSafety) {
   Json runtime;


### PR DESCRIPTION
## Summary
- Map RuntimeOptions socks5Proxy/socks5NetWork/noProxy through Core into MCurlHttpClient with CURLPROXY_SOCKS5 and fail-fast validation.
- Proxy priority follows Java (http → https → socks5); socks5h uses remote DNS resolution.
- Add unit/integration tests for proxy validation and Core runtime wiring.